### PR TITLE
Feature/hounslow ch198 global admins to skip update request flow

### DIFF
--- a/src/components/CkUserDetails.vue
+++ b/src/components/CkUserDetails.vue
@@ -21,8 +21,8 @@
         <gov-table-header top scope="row">Permissions</gov-table-header>
         <gov-table-cell>
           <gov-list>
-            <li>Super admin: {{ superAdmin ? 'Yes' : 'No' }}</li>
-            <li>Global admin: {{ globalAdmin ? 'Yes' : 'No' }}</li>
+            <li>Super admin: {{ superAdmin ? "Yes" : "No" }}</li>
+            <li>Global admin: {{ globalAdmin ? "Yes" : "No" }}</li>
             <li>
               <template v-if="organisationAdmin.length === 0"
                 >Organisation admin: No</template
@@ -36,7 +36,7 @@
                   <gov-link
                     :to="{
                       name: 'organisations-show',
-                      params: { organisation: role.organisation_id },
+                      params: { organisation: role.organisation_id }
                     }"
                     v-text="role.organisation.name"
                   />
@@ -56,7 +56,7 @@
                   <gov-link
                     :to="{
                       name: 'services-show',
-                      params: { service: role.service_id },
+                      params: { service: role.service_id }
                     }"
                     v-text="role.service.name"
                   />
@@ -76,7 +76,7 @@
                   <gov-link
                     :to="{
                       name: 'services-show',
-                      params: { service: role.service_id },
+                      params: { service: role.service_id }
                     }"
                     v-text="role.service.name"
                   />
@@ -91,54 +91,54 @@
 </template>
 
 <script>
-  export default {
-    name: 'CkUserDetails',
-    props: {
-      user: {
-        type: Object,
-        required: true,
-      },
-    },
-    data() {
-      return {
-        superAdmin: false,
-        globalAdmin: false,
-        organisationAdmin: [],
-        serviceAdmin: [],
-        serviceWorker: [],
-      };
-    },
-    methods: {
-      sortRoles() {
-        this.superAdmin = false;
-        this.globalAdmin = false;
-        this.organisationAdmin = [];
-        this.serviceAdmin = [];
-        this.serviceWorker = [];
+export default {
+  name: "CkUserDetails",
+  props: {
+    user: {
+      type: Object,
+      required: true
+    }
+  },
+  data() {
+    return {
+      superAdmin: false,
+      globalAdmin: false,
+      organisationAdmin: [],
+      serviceAdmin: [],
+      serviceWorker: []
+    };
+  },
+  methods: {
+    sortRoles() {
+      this.superAdmin = false;
+      this.globalAdmin = false;
+      this.organisationAdmin = [];
+      this.serviceAdmin = [];
+      this.serviceWorker = [];
 
-        this.user.roles.forEach((role) => {
-          if (role.role === 'Super Admin') {
-            this.superAdmin = true;
-          } else if (role.role === 'Global Admin') {
-            this.globalAdmin = true;
-          } else if (role.hasOwnProperty('organisation_id')) {
-            this.organisationAdmin.push(role);
-          } else if (
-            role.hasOwnProperty('service_id') &&
-            role.role === 'Service Admin'
-          ) {
-            this.serviceAdmin.push(role);
-          } else if (
-            role.hasOwnProperty('service_id') &&
-            role.role === 'Service Worker'
-          ) {
-            this.serviceWorker.push(role);
-          }
-        });
-      },
-    },
-    created() {
-      this.sortRoles();
-    },
-  };
+      this.user.roles.forEach(role => {
+        if (role.role === "Super Admin") {
+          this.superAdmin = true;
+        } else if (role.role === "Global Admin") {
+          this.globalAdmin = true;
+        } else if (role.hasOwnProperty("organisation_id")) {
+          this.organisationAdmin.push(role);
+        } else if (
+          role.hasOwnProperty("service_id") &&
+          role.role === "Service Admin"
+        ) {
+          this.serviceAdmin.push(role);
+        } else if (
+          role.hasOwnProperty("service_id") &&
+          role.role === "Service Worker"
+        ) {
+          this.serviceWorker.push(role);
+        }
+      });
+    }
+  },
+  created() {
+    this.sortRoles();
+  }
+};
 </script>

--- a/src/components/CkUserDetails.vue
+++ b/src/components/CkUserDetails.vue
@@ -21,8 +21,8 @@
         <gov-table-header top scope="row">Permissions</gov-table-header>
         <gov-table-cell>
           <gov-list>
-            <li>Super admin: {{ superAdmin ? "Yes" : "No" }}</li>
-            <li>Global admin: {{ globalAdmin ? "Yes" : "No" }}</li>
+            <li>Super admin: {{ superAdmin ? 'Yes' : 'No' }}</li>
+            <li>Global admin: {{ globalAdmin ? 'Yes' : 'No' }}</li>
             <li>
               <template v-if="organisationAdmin.length === 0"
                 >Organisation admin: No</template
@@ -36,7 +36,7 @@
                   <gov-link
                     :to="{
                       name: 'organisations-show',
-                      params: { organisation: role.organisation_id }
+                      params: { organisation: role.organisation_id },
                     }"
                     v-text="role.organisation.name"
                   />
@@ -56,7 +56,7 @@
                   <gov-link
                     :to="{
                       name: 'services-show',
-                      params: { service: role.service_id }
+                      params: { service: role.service_id },
                     }"
                     v-text="role.service.name"
                   />
@@ -76,7 +76,7 @@
                   <gov-link
                     :to="{
                       name: 'services-show',
-                      params: { service: role.service_id }
+                      params: { service: role.service_id },
                     }"
                     v-text="role.service.name"
                   />
@@ -91,54 +91,54 @@
 </template>
 
 <script>
-export default {
-  name: "CkUserDetails",
-  props: {
-    user: {
-      type: Object,
-      required: true
-    }
-  },
-  data() {
-    return {
-      superAdmin: false,
-      globalAdmin: false,
-      organisationAdmin: [],
-      serviceAdmin: [],
-      serviceWorker: []
-    };
-  },
-  methods: {
-    sortRoles() {
-      this.superAdmin = false;
-      this.globalAdmin = false;
-      this.organisationAdmin = [];
-      this.serviceAdmin = [];
-      this.serviceWorker = [];
+  export default {
+    name: 'CkUserDetails',
+    props: {
+      user: {
+        type: Object,
+        required: true,
+      },
+    },
+    data() {
+      return {
+        superAdmin: false,
+        globalAdmin: false,
+        organisationAdmin: [],
+        serviceAdmin: [],
+        serviceWorker: [],
+      };
+    },
+    methods: {
+      sortRoles() {
+        this.superAdmin = false;
+        this.globalAdmin = false;
+        this.organisationAdmin = [];
+        this.serviceAdmin = [];
+        this.serviceWorker = [];
 
-      this.user.roles.forEach(role => {
-        if (role.role === "Super Admin") {
-          this.superAdmin = true;
-        } else if (role.role === "Global Admin") {
-          this.globalAdmin = true;
-        } else if (role.hasOwnProperty("organisation")) {
-          this.organisationAdmin.push(role);
-        } else if (
-          role.hasOwnProperty("service") &&
-          role.role === "Service Admin"
-        ) {
-          this.serviceAdmin.push(role);
-        } else if (
-          role.hasOwnProperty("service") &&
-          role.role === "Service Worker"
-        ) {
-          this.serviceWorker.push(role);
-        }
-      });
-    }
-  },
-  created() {
-    this.sortRoles();
-  }
-};
+        this.user.roles.forEach((role) => {
+          if (role.role === 'Super Admin') {
+            this.superAdmin = true;
+          } else if (role.role === 'Global Admin') {
+            this.globalAdmin = true;
+          } else if (role.hasOwnProperty('organisation_id')) {
+            this.organisationAdmin.push(role);
+          } else if (
+            role.hasOwnProperty('service_id') &&
+            role.role === 'Service Admin'
+          ) {
+            this.serviceAdmin.push(role);
+          } else if (
+            role.hasOwnProperty('service_id') &&
+            role.role === 'Service Worker'
+          ) {
+            this.serviceWorker.push(role);
+          }
+        });
+      },
+    },
+    created() {
+      this.sortRoles();
+    },
+  };
 </script>

--- a/src/views/locations/Edit.vue
+++ b/src/views/locations/Edit.vue
@@ -58,122 +58,121 @@
 </template>
 
 <script>
-  import http from '@/http';
-  import Form from '@/classes/Form';
-  import LocationForm from '@/views/locations/forms/LocationForm';
+import http from "@/http";
+import Form from "@/classes/Form";
+import LocationForm from "@/views/locations/forms/LocationForm";
 
-  export default {
-    name: 'EditLocation',
-    components: { LocationForm },
-    data() {
-      return {
-        loading: false,
-        location: null,
-        form: null,
-      };
+export default {
+  name: "EditLocation",
+  components: { LocationForm },
+  data() {
+    return {
+      loading: false,
+      location: null,
+      form: null
+    };
+  },
+  computed: {
+    updateButtonText() {
+      return this.auth.isGlobalAdmin ? "Update" : "Request update";
+    }
+  },
+  methods: {
+    async fetchLocation() {
+      this.loading = true;
+
+      const response = await http.get(
+        `/locations/${this.$route.params.location}`
+      );
+      this.location = response.data.data;
+      this.form = new Form({
+        address_line_1: this.location.address_line_1,
+        address_line_2: this.location.address_line_2 || "",
+        address_line_3: this.location.address_line_3 || "",
+        city: this.location.city,
+        county: this.location.county,
+        postcode: this.location.postcode,
+        country: this.location.country,
+        accessibility_info: this.location.accessibility_info || "",
+        has_wheelchair_access: this.location.has_wheelchair_access,
+        has_induction_loop: this.location.has_induction_loop,
+        image_file_id: null
+      });
+
+      this.loading = false;
     },
-    computed: {
-      updateButtonText() {
-        return this.auth.isGlobalAdmin ? 'Update' : 'Request update';
-      },
-    },
-    methods: {
-      async fetchLocation() {
-        this.loading = true;
-
-        const response = await http.get(
-          `/locations/${this.$route.params.location}`
-        );
-        this.location = response.data.data;
-        this.form = new Form({
-          address_line_1: this.location.address_line_1,
-          address_line_2: this.location.address_line_2 || '',
-          address_line_3: this.location.address_line_3 || '',
-          city: this.location.city,
-          county: this.location.county,
-          postcode: this.location.postcode,
-          country: this.location.country,
-          accessibility_info: this.location.accessibility_info || '',
-          has_wheelchair_access: this.location.has_wheelchair_access,
-          has_induction_loop: this.location.has_induction_loop,
-          image_file_id: null,
-        });
-
-        this.loading = false;
-      },
-      async onSubmit() {
-        const response = await this.form.put(
-          `/locations/${this.location.id}`,
-          (config, data) => {
-            // Remove any unchanged values.
-            if (data.address_line_1 === this.location.address_line_1) {
-              delete data.address_line_1;
-            }
-            if (data.address_line_2 === (this.location.address_line_2 || '')) {
-              delete data.address_line_2;
-            }
-            if (data.address_line_3 === (this.location.address_line_3 || '')) {
-              delete data.address_line_3;
-            }
-            if (data.city === this.location.city) {
-              delete data.city;
-            }
-            if (data.county === this.location.county) {
-              delete data.county;
-            }
-            if (data.postcode === this.location.postcode) {
-              delete data.postcode;
-            }
-            if (data.country === this.location.country) {
-              delete data.country;
-            }
-            if (
-              data.accessibility_info ===
-              (this.location.accessibility_info || '')
-            ) {
-              delete data.accessibility_info;
-            }
-            if (
-              data.has_wheelchair_access === this.location.has_wheelchair_access
-            ) {
-              delete data.has_wheelchair_access;
-            }
-            if (data.has_induction_loop === this.location.has_induction_loop) {
-              delete data.has_induction_loop;
-            }
-            // Remove the logo from the request if null, or delete if false.
-            if (data.image_file_id === null) {
-              delete data.image_file_id;
-            } else if (data.image_file_id === false) {
-              data.image_file_id = null;
-            }
+    async onSubmit() {
+      const response = await this.form.put(
+        `/locations/${this.location.id}`,
+        (config, data) => {
+          // Remove any unchanged values.
+          if (data.address_line_1 === this.location.address_line_1) {
+            delete data.address_line_1;
           }
-        );
-
-        const updateRequestId = response.id;
-        let next = {
-          name: 'locations-updated',
-          params: { location: this.location.id },
-        };
-
-        if (this.auth.isGlobalAdmin) {
-          try {
-            const { data } = await http.get(
-              `/update-requests/${updateRequestId}`
-            );
-            if (data.approved_at) {
-              next.name = 'locations-show';
-              next.query = { updated: true };
-            }
-          } catch (err) {
-            console.log(err);
+          if (data.address_line_2 === (this.location.address_line_2 || "")) {
+            delete data.address_line_2;
+          }
+          if (data.address_line_3 === (this.location.address_line_3 || "")) {
+            delete data.address_line_3;
+          }
+          if (data.city === this.location.city) {
+            delete data.city;
+          }
+          if (data.county === this.location.county) {
+            delete data.county;
+          }
+          if (data.postcode === this.location.postcode) {
+            delete data.postcode;
+          }
+          if (data.country === this.location.country) {
+            delete data.country;
+          }
+          if (
+            data.accessibility_info === (this.location.accessibility_info || "")
+          ) {
+            delete data.accessibility_info;
+          }
+          if (
+            data.has_wheelchair_access === this.location.has_wheelchair_access
+          ) {
+            delete data.has_wheelchair_access;
+          }
+          if (data.has_induction_loop === this.location.has_induction_loop) {
+            delete data.has_induction_loop;
+          }
+          // Remove the logo from the request if null, or delete if false.
+          if (data.image_file_id === null) {
+            delete data.image_file_id;
+          } else if (data.image_file_id === false) {
+            data.image_file_id = null;
           }
         }
-        this.$router.push(next);
-      },
-    },
-    created() {
-      this.fetchLocation();
-    },
-  };
+      );
+
+      const updateRequestId = response.id;
+      let next = {
+        name: "locations-updated",
+        params: { location: this.location.id }
+      };
+
+      if (this.auth.isGlobalAdmin) {
+        try {
+          const { data } = await http.get(
+            `/update-requests/${updateRequestId}`
+          );
+          if (data.approved_at) {
+            next.name = "locations-show";
+            next.query = { updated: true };
+          }
+        } catch (err) {
+          console.log(err);
+        }
+      }
+      this.$router.push(next);
+    }
+  },
+  created() {
+    this.fetchLocation();
+  }
+};
 </script>

--- a/src/views/locations/Edit.vue
+++ b/src/views/locations/Edit.vue
@@ -46,9 +46,9 @@
             <gov-button v-if="form.$submitting" disabled type="submit"
               >Requesting...</gov-button
             >
-            <gov-button v-else @click="onSubmit" type="submit"
-              >Request update</gov-button
-            >
+            <gov-button v-else @click="onSubmit" type="submit">{{
+              updateButtonText
+            }}</gov-button>
             <ck-submit-error v-if="form.$errors.any()" />
           </gov-grid-column>
         </gov-grid-row>
@@ -58,97 +58,122 @@
 </template>
 
 <script>
-import http from "@/http";
-import Form from "@/classes/Form";
-import LocationForm from "@/views/locations/forms/LocationForm";
+  import http from '@/http';
+  import Form from '@/classes/Form';
+  import LocationForm from '@/views/locations/forms/LocationForm';
 
-export default {
-  name: "EditLocation",
-  components: { LocationForm },
-  data() {
-    return {
-      loading: false,
-      location: null,
-      form: null
-    };
-  },
-  methods: {
-    async fetchLocation() {
-      this.loading = true;
-
-      const response = await http.get(
-        `/locations/${this.$route.params.location}`
-      );
-      this.location = response.data.data;
-      this.form = new Form({
-        address_line_1: this.location.address_line_1,
-        address_line_2: this.location.address_line_2 || "",
-        address_line_3: this.location.address_line_3 || "",
-        city: this.location.city,
-        county: this.location.county,
-        postcode: this.location.postcode,
-        country: this.location.country,
-        accessibility_info: this.location.accessibility_info || "",
-        has_wheelchair_access: this.location.has_wheelchair_access,
-        has_induction_loop: this.location.has_induction_loop,
-        image_file_id: null
-      });
-
-      this.loading = false;
+  export default {
+    name: 'EditLocation',
+    components: { LocationForm },
+    data() {
+      return {
+        loading: false,
+        location: null,
+        form: null,
+      };
     },
-    async onSubmit() {
-      await this.form.put(`/locations/${this.location.id}`, (config, data) => {
-        // Remove any unchanged values.
-        if (data.address_line_1 === this.location.address_line_1) {
-          delete data.address_line_1;
-        }
-        if (data.address_line_2 === (this.location.address_line_2 || "")) {
-          delete data.address_line_2;
-        }
-        if (data.address_line_3 === (this.location.address_line_3 || "")) {
-          delete data.address_line_3;
-        }
-        if (data.city === this.location.city) {
-          delete data.city;
-        }
-        if (data.county === this.location.county) {
-          delete data.county;
-        }
-        if (data.postcode === this.location.postcode) {
-          delete data.postcode;
-        }
-        if (data.country === this.location.country) {
-          delete data.country;
-        }
-        if (
-          data.accessibility_info === (this.location.accessibility_info || "")
-        ) {
-          delete data.accessibility_info;
-        }
-        if (
-          data.has_wheelchair_access === this.location.has_wheelchair_access
-        ) {
-          delete data.has_wheelchair_access;
-        }
-        if (data.has_induction_loop === this.location.has_induction_loop) {
-          delete data.has_induction_loop;
-        }
-        // Remove the logo from the request if null, or delete if false.
-        if (data.image_file_id === null) {
-          delete data.image_file_id;
-        } else if (data.image_file_id === false) {
-          data.image_file_id = null;
-        }
-      });
+    computed: {
+      updateButtonText() {
+        return this.auth.isGlobalAdmin ? 'Update' : 'Request update';
+      },
+    },
+    methods: {
+      async fetchLocation() {
+        this.loading = true;
 
-      this.$router.push({
-        name: "locations-updated",
-        params: { location: this.location.id }
-      });
-    }
-  },
-  created() {
-    this.fetchLocation();
-  }
-};
+        const response = await http.get(
+          `/locations/${this.$route.params.location}`
+        );
+        this.location = response.data.data;
+        this.form = new Form({
+          address_line_1: this.location.address_line_1,
+          address_line_2: this.location.address_line_2 || '',
+          address_line_3: this.location.address_line_3 || '',
+          city: this.location.city,
+          county: this.location.county,
+          postcode: this.location.postcode,
+          country: this.location.country,
+          accessibility_info: this.location.accessibility_info || '',
+          has_wheelchair_access: this.location.has_wheelchair_access,
+          has_induction_loop: this.location.has_induction_loop,
+          image_file_id: null,
+        });
+
+        this.loading = false;
+      },
+      async onSubmit() {
+        const response = await this.form.put(
+          `/locations/${this.location.id}`,
+          (config, data) => {
+            // Remove any unchanged values.
+            if (data.address_line_1 === this.location.address_line_1) {
+              delete data.address_line_1;
+            }
+            if (data.address_line_2 === (this.location.address_line_2 || '')) {
+              delete data.address_line_2;
+            }
+            if (data.address_line_3 === (this.location.address_line_3 || '')) {
+              delete data.address_line_3;
+            }
+            if (data.city === this.location.city) {
+              delete data.city;
+            }
+            if (data.county === this.location.county) {
+              delete data.county;
+            }
+            if (data.postcode === this.location.postcode) {
+              delete data.postcode;
+            }
+            if (data.country === this.location.country) {
+              delete data.country;
+            }
+            if (
+              data.accessibility_info ===
+              (this.location.accessibility_info || '')
+            ) {
+              delete data.accessibility_info;
+            }
+            if (
+              data.has_wheelchair_access === this.location.has_wheelchair_access
+            ) {
+              delete data.has_wheelchair_access;
+            }
+            if (data.has_induction_loop === this.location.has_induction_loop) {
+              delete data.has_induction_loop;
+            }
+            // Remove the logo from the request if null, or delete if false.
+            if (data.image_file_id === null) {
+              delete data.image_file_id;
+            } else if (data.image_file_id === false) {
+              data.image_file_id = null;
+            }
+          }
+        );
+
+        const updateRequestId = response.id;
+        let next = {
+          name: 'locations-updated',
+          params: { location: this.location.id },
+        };
+
+        if (this.auth.isGlobalAdmin) {
+          try {
+            const { data } = await http.get(
+              `/update-requests/${updateRequestId}`
+            );
+            if (data.approved_at) {
+              next.name = 'locations-show';
+              next.query = { updated: true };
+            }
+          } catch (err) {
+            console.log(err);
+          }
+        }
+        this.$router.push(next);
+      },
+    },
+    created() {
+      this.fetchLocation();
+    },
+  };
 </script>

--- a/src/views/locations/Show.vue
+++ b/src/views/locations/Show.vue
@@ -13,6 +13,11 @@
         <gov-grid-column width="two-thirds">
           <gov-heading size="m">View location</gov-heading>
 
+          <gov-inset-text v-if="updated"
+            >Location {{ location.address_line_1 }} has been
+            updated</gov-inset-text
+          >
+
           <location-details :location="location" />
 
           <template v-if="auth.isGlobalAdmin">
@@ -46,35 +51,37 @@
 </template>
 
 <script>
-import LocationDetails from "@/views/locations/show/LocationDetails";
-import http from "@/http";
+  import LocationDetails from '@/views/locations/show/LocationDetails';
+  import http from '@/http';
 
-export default {
-  name: "ShowLocation",
-  components: { LocationDetails },
-  data() {
-    return {
-      loading: false,
-      location: null
-    };
-  },
-  methods: {
-    async fetchLocation() {
-      this.loading = true;
-
-      const response = await http.get(
-        `/locations/${this.$route.params.location}`
-      );
-      this.location = response.data.data;
-
-      this.loading = false;
+  export default {
+    name: 'ShowLocation',
+    components: { LocationDetails },
+    data() {
+      return {
+        loading: false,
+        location: null,
+        updated: false,
+      };
     },
-    onDelete() {
-      this.$router.push({ name: "locations-index" });
-    }
-  },
-  created() {
-    this.fetchLocation();
-  }
-};
+    methods: {
+      async fetchLocation() {
+        this.loading = true;
+
+        const response = await http.get(
+          `/locations/${this.$route.params.location}`
+        );
+        this.location = response.data.data;
+
+        this.loading = false;
+      },
+      onDelete() {
+        this.$router.push({ name: 'locations-index' });
+      },
+    },
+    created() {
+      this.updated = this.$route.query.updated || false;
+      this.fetchLocation();
+    },
+  };
 </script>

--- a/src/views/locations/Show.vue
+++ b/src/views/locations/Show.vue
@@ -51,37 +51,37 @@
 </template>
 
 <script>
-  import LocationDetails from '@/views/locations/show/LocationDetails';
-  import http from '@/http';
+import LocationDetails from "@/views/locations/show/LocationDetails";
+import http from "@/http";
 
-  export default {
-    name: 'ShowLocation',
-    components: { LocationDetails },
-    data() {
-      return {
-        loading: false,
-        location: null,
-        updated: false,
-      };
-    },
-    methods: {
-      async fetchLocation() {
-        this.loading = true;
+export default {
+  name: "ShowLocation",
+  components: { LocationDetails },
+  data() {
+    return {
+      loading: false,
+      location: null,
+      updated: false
+    };
+  },
+  methods: {
+    async fetchLocation() {
+      this.loading = true;
 
-        const response = await http.get(
-          `/locations/${this.$route.params.location}`
-        );
-        this.location = response.data.data;
+      const response = await http.get(
+        `/locations/${this.$route.params.location}`
+      );
+      this.location = response.data.data;
 
-        this.loading = false;
-      },
-      onDelete() {
-        this.$router.push({ name: 'locations-index' });
-      },
+      this.loading = false;
     },
-    created() {
-      this.updated = this.$route.query.updated || false;
-      this.fetchLocation();
-    },
-  };
+    onDelete() {
+      this.$router.push({ name: "locations-index" });
+    }
+  },
+  created() {
+    this.updated = this.$route.query.updated || false;
+    this.fetchLocation();
+  }
+};
 </script>

--- a/src/views/organisations/Edit.vue
+++ b/src/views/organisations/Edit.vue
@@ -11,7 +11,7 @@
       <gov-back-link
         :to="{
           name: 'organisations-show',
-          params: { organisation: organisation.id },
+          params: { organisation: organisation.id }
         }"
         >Back to organisation</gov-back-link
       >
@@ -112,140 +112,138 @@
 </template>
 
 <script>
-  import http from '@/http';
-  import Form from '@/classes/Form';
-  import OrganisationTab from './OrganisationTab';
-  import OrganisationForm from './forms/OrganisationForm';
-  import CkCategoryTaxonomyInput from '@/components/Ck/CkCategoryTaxonomyInput';
+import http from "@/http";
+import Form from "@/classes/Form";
+import OrganisationTab from "./OrganisationTab";
+import OrganisationForm from "./forms/OrganisationForm";
+import CkCategoryTaxonomyInput from "@/components/Ck/CkCategoryTaxonomyInput";
 
-  export default {
-    name: 'EditOrganisation',
-    components: { OrganisationForm, OrganisationTab, CkCategoryTaxonomyInput },
-    data() {
-      return {
-        loading: false,
-        organisation: null,
-        form: null,
-        tabs: [
-          { id: 'details', heading: 'Details', active: true },
-          { id: 'taxonomies', heading: 'Taxonomies', active: false },
-        ],
-      };
+export default {
+  name: "EditOrganisation",
+  components: { OrganisationForm, OrganisationTab, CkCategoryTaxonomyInput },
+  data() {
+    return {
+      loading: false,
+      organisation: null,
+      form: null,
+      tabs: [
+        { id: "details", heading: "Details", active: true },
+        { id: "taxonomies", heading: "Taxonomies", active: false }
+      ]
+    };
+  },
+  computed: {
+    updateButtonText() {
+      return this.auth.isGlobalAdmin ? "Update" : "Request update";
+    }
+  },
+  methods: {
+    async fetchOrganisation() {
+      this.loading = true;
+
+      const response = await http.get(
+        `/organisations/${this.$route.params.organisation}`
+      );
+      this.organisation = response.data.data;
+      this.form = new Form({
+        name: this.organisation.name,
+        slug: this.organisation.slug,
+        description: this.organisation.description,
+        url: this.organisation.url,
+        email: this.organisation.email || "",
+        phone: this.organisation.phone || "",
+        logo_file_id: null,
+        social_medias: this.organisation.social_medias,
+        category_taxonomies: this.organisation.category_taxonomies.map(
+          taxonomy => taxonomy.id
+        )
+      });
+
+      this.loading = false;
     },
-    computed: {
-      updateButtonText() {
-        return this.auth.isGlobalAdmin ? 'Update' : 'Request update';
-      },
-    },
-    methods: {
-      async fetchOrganisation() {
-        this.loading = true;
-
-        const response = await http.get(
-          `/organisations/${this.$route.params.organisation}`
-        );
-        this.organisation = response.data.data;
-        this.form = new Form({
-          name: this.organisation.name,
-          slug: this.organisation.slug,
-          description: this.organisation.description,
-          url: this.organisation.url,
-          email: this.organisation.email || '',
-          phone: this.organisation.phone || '',
-          logo_file_id: null,
-          social_medias: this.organisation.social_medias,
-          category_taxonomies: this.organisation.category_taxonomies.map(
-            (taxonomy) => taxonomy.id
-          ),
-        });
-
-        this.loading = false;
-      },
-      async onSubmit() {
-        const response = await this.form.put(
-          `/organisations/${this.organisation.id}`,
-          (config, data) => {
-            // Remove any unchanged values.
-            if (data.name === this.organisation.name) {
-              delete data.name;
-            }
-            if (data.slug === this.organisation.slug) {
-              delete data.slug;
-            }
-            if (data.description === this.organisation.description) {
-              delete data.description;
-            }
-            if (data.url === this.organisation.url) {
-              delete data.url;
-            }
-            if (data.email === (this.organisation.email || '-')) {
-              delete data.email;
-            }
-            if (data.phone === (this.organisation.phone || '-')) {
-              delete data.phone;
-            }
-
-            // Remove the logo from the request if null, or delete if false.
-            if (data.logo_file_id === null) {
-              delete data.logo_file_id;
-            } else if (data.logo_file_id === false) {
-              data.logo_file_id = null;
-            }
-
-            if (
-              JSON.stringify(data.social_medias) ===
-              JSON.stringify(this.organisation.social_medias)
-            ) {
-              delete data.social_medias;
-            }
-
-            if (
-              JSON.stringify(data.category_taxonomies) ===
-              JSON.stringify(
-                this.organisation.category_taxonomies.map(
-                  (taxonomy) => taxonomy.id
-                )
-              )
-            ) {
-              delete data.category_taxonomies;
-            }
+    async onSubmit() {
+      const response = await this.form.put(
+        `/organisations/${this.organisation.id}`,
+        (config, data) => {
+          // Remove any unchanged values.
+          if (data.name === this.organisation.name) {
+            delete data.name;
           }
-        );
-        const updateRequestId = response.id;
-        let next = {
-          name: 'organisations-updated',
-          params: { organisation: this.organisation.id },
-        };
+          if (data.slug === this.organisation.slug) {
+            delete data.slug;
+          }
+          if (data.description === this.organisation.description) {
+            delete data.description;
+          }
+          if (data.url === this.organisation.url) {
+            delete data.url;
+          }
+          if (data.email === (this.organisation.email || "-")) {
+            delete data.email;
+          }
+          if (data.phone === (this.organisation.phone || "-")) {
+            delete data.phone;
+          }
 
-        if (this.auth.isGlobalAdmin) {
-          try {
-            const { data } = await http.get(
-              `/update-requests/${updateRequestId}`
-            );
+          // Remove the logo from the request if null, or delete if false.
+          if (data.logo_file_id === null) {
+            delete data.logo_file_id;
+          } else if (data.logo_file_id === false) {
+            data.logo_file_id = null;
+          }
 
-            if (data.approved_at) {
-              next.name = 'organisations-show';
-              next.query = { updated: true };
-            }
-          } catch (err) {
-            console.log(err);
+          if (
+            JSON.stringify(data.social_medias) ===
+            JSON.stringify(this.organisation.social_medias)
+          ) {
+            delete data.social_medias;
+          }
+
+          if (
+            JSON.stringify(data.category_taxonomies) ===
+            JSON.stringify(
+              this.organisation.category_taxonomies.map(taxonomy => taxonomy.id)
+            )
+          ) {
+            delete data.category_taxonomies;
           }
         }
-        this.$router.push(next);
-      },
-      onTabChange({ index }) {
-        this.tabs.forEach((tab) => (tab.active = false));
-        const tabId = this.tabs[index].id;
-        this.tabs.find((tab) => tab.id === tabId).active = true;
-      },
-      isTabActive(id) {
-        const tab = this.tabs.find((tab) => tab.id === id);
+      );
+      const updateRequestId = response.id;
+      let next = {
+        name: "organisations-updated",
+        params: { organisation: this.organisation.id }
+      };
 
-        return tab === undefined ? false : tab.active;
-      },
+      if (this.auth.isGlobalAdmin) {
+        try {
+          const { data } = await http.get(
+            `/update-requests/${updateRequestId}`
+          );
+
+          if (data.approved_at) {
+            next.name = "organisations-show";
+            next.query = { updated: true };
+          }
+        } catch (err) {
+          console.log(err);
+        }
+      }
+      this.$router.push(next);
     },
-    created() {
-      this.fetchOrganisation();
+    onTabChange({ index }) {
+      this.tabs.forEach(tab => (tab.active = false));
+      const tabId = this.tabs[index].id;
+      this.tabs.find(tab => tab.id === tabId).active = true;
     },
-  };
+    isTabActive(id) {
+      const tab = this.tabs.find(tab => tab.id === id);
+
+      return tab === undefined ? false : tab.active;
+    }
+  },
+  created() {
+    this.fetchOrganisation();
+  }
+};
 </script>

--- a/src/views/organisations/Show.vue
+++ b/src/views/organisations/Show.vue
@@ -43,7 +43,7 @@
           <gov-button
             :to="{
               name: 'organisations-edit',
-              params: { organisation: organisation.id },
+              params: { organisation: organisation.id }
             }"
           >
             Edit organisation
@@ -55,34 +55,34 @@
 </template>
 
 <script>
-  import http from '@/http';
+import http from "@/http";
 
-  export default {
-    name: 'ShowOrganisation',
-    data() {
-      return {
-        loading: false,
-        updated: false,
-        organisation: null,
-      };
+export default {
+  name: "ShowOrganisation",
+  data() {
+    return {
+      loading: false,
+      updated: false,
+      organisation: null
+    };
+  },
+  methods: {
+    fetchOrganisation() {
+      this.loading = true;
+      http
+        .get(`/organisations/${this.$route.params.organisation}`)
+        .then(({ data }) => {
+          this.organisation = data.data;
+          this.loading = false;
+        });
     },
-    methods: {
-      fetchOrganisation() {
-        this.loading = true;
-        http
-          .get(`/organisations/${this.$route.params.organisation}`)
-          .then(({ data }) => {
-            this.organisation = data.data;
-            this.loading = false;
-          });
-      },
-      onDelete() {
-        this.$router.push({ name: 'organisations-index' });
-      },
-    },
-    created() {
-      this.updated = this.$route.query.updated || false;
-      this.fetchOrganisation();
-    },
-  };
+    onDelete() {
+      this.$router.push({ name: "organisations-index" });
+    }
+  },
+  created() {
+    this.updated = this.$route.query.updated || false;
+    this.fetchOrganisation();
+  }
+};
 </script>

--- a/src/views/organisations/Show.vue
+++ b/src/views/organisations/Show.vue
@@ -13,6 +13,11 @@
         <gov-grid-column width="two-thirds">
           <gov-heading size="m">View organisation</gov-heading>
 
+          <gov-inset-text v-if="updated"
+            >Organisation {{ organisation.name }} has been
+            updated</gov-inset-text
+          >
+
           <ck-organisation-details :organisation="organisation" />
 
           <template v-if="auth.isSuperAdmin">
@@ -38,7 +43,7 @@
           <gov-button
             :to="{
               name: 'organisations-edit',
-              params: { organisation: organisation.id }
+              params: { organisation: organisation.id },
             }"
           >
             Edit organisation
@@ -50,32 +55,34 @@
 </template>
 
 <script>
-import http from "@/http";
+  import http from '@/http';
 
-export default {
-  name: "ShowOrganisation",
-  data() {
-    return {
-      loading: false,
-      organisation: null
-    };
-  },
-  methods: {
-    fetchOrganisation() {
-      this.loading = true;
-      http
-        .get(`/organisations/${this.$route.params.organisation}`)
-        .then(({ data }) => {
-          this.organisation = data.data;
-          this.loading = false;
-        });
+  export default {
+    name: 'ShowOrganisation',
+    data() {
+      return {
+        loading: false,
+        updated: false,
+        organisation: null,
+      };
     },
-    onDelete() {
-      this.$router.push({ name: "organisations-index" });
-    }
-  },
-  created() {
-    this.fetchOrganisation();
-  }
-};
+    methods: {
+      fetchOrganisation() {
+        this.loading = true;
+        http
+          .get(`/organisations/${this.$route.params.organisation}`)
+          .then(({ data }) => {
+            this.organisation = data.data;
+            this.loading = false;
+          });
+      },
+      onDelete() {
+        this.$router.push({ name: 'organisations-index' });
+      },
+    },
+    created() {
+      this.updated = this.$route.query.updated || false;
+      this.fetchOrganisation();
+    },
+  };
 </script>

--- a/src/views/service-locations/Edit.vue
+++ b/src/views/service-locations/Edit.vue
@@ -12,7 +12,7 @@
       <gov-back-link
         :to="{
           name: 'service-locations-show',
-          params: { serviceLocation: serviceLocation.id }
+          params: { serviceLocation: serviceLocation.id },
         }"
         >Back to service location</gov-back-link
       >
@@ -40,9 +40,9 @@
             <gov-button v-if="form.$submitting" disabled type="submit"
               >Requesting...</gov-button
             >
-            <gov-button v-else @click="onSubmit" type="submit"
-              >Request update</gov-button
-            >
+            <gov-button v-else @click="onSubmit" type="submit">{{
+              updateButtonText
+            }}</gov-button>
             <ck-submit-error v-if="form.$errors.any()" />
           </gov-grid-column>
         </gov-grid-row>
@@ -52,72 +52,93 @@
 </template>
 
 <script>
-import Form from "@/classes/Form";
-import ServiceLocationForm from "@/views/service-locations/forms/ServiceLocationForm";
-import http from "@/http";
+  import Form from '@/classes/Form';
+  import ServiceLocationForm from '@/views/service-locations/forms/ServiceLocationForm';
+  import http from '@/http';
 
-export default {
-  name: "EditServiceLocation",
-  components: { ServiceLocationForm },
-  data() {
-    return {
-      form: null,
-      serviceLocation: null,
-      loading: false
-    };
-  },
-  methods: {
-    async fetchServiceLocation() {
-      this.loading = true;
-      const response = await http.get(
-        `/service-locations/${this.$route.params.serviceLocation}`
-      );
-      this.serviceLocation = response.data.data;
-      this.form = new Form({
-        name: this.serviceLocation.name || "",
-        regular_opening_hours: this.serviceLocation.regular_opening_hours,
-        holiday_opening_hours: this.serviceLocation.holiday_opening_hours,
-        image_file_id: null
-      });
-      this.loading = false;
+  export default {
+    name: 'EditServiceLocation',
+    components: { ServiceLocationForm },
+    data() {
+      return {
+        form: null,
+        serviceLocation: null,
+        loading: false,
+      };
     },
-    async onSubmit() {
-      await this.form.put(
-        `/service-locations/${this.serviceLocation.id}`,
-        (config, data) => {
-          // Remove any unchanged values.
-          if (data.name === (this.serviceLocation.name || "")) {
-            delete data.name;
+    computed: {
+      updateButtonText() {
+        return this.auth.isGlobalAdmin ? 'Update' : 'Request update';
+      },
+    },
+    methods: {
+      async fetchServiceLocation() {
+        this.loading = true;
+        const response = await http.get(
+          `/service-locations/${this.$route.params.serviceLocation}`
+        );
+        this.serviceLocation = response.data.data;
+        this.form = new Form({
+          name: this.serviceLocation.name || '',
+          regular_opening_hours: this.serviceLocation.regular_opening_hours,
+          holiday_opening_hours: this.serviceLocation.holiday_opening_hours,
+          image_file_id: null,
+        });
+        this.loading = false;
+      },
+      async onSubmit() {
+        const response = await this.form.put(
+          `/service-locations/${this.serviceLocation.id}`,
+          (config, data) => {
+            // Remove any unchanged values.
+            if (data.name === (this.serviceLocation.name || '')) {
+              delete data.name;
+            }
+            if (
+              JSON.stringify(data.regular_opening_hours) ===
+              JSON.stringify(this.serviceLocation.regular_opening_hours)
+            ) {
+              delete data.regular_opening_hours;
+            }
+            if (
+              JSON.stringify(data.holiday_opening_hours) ===
+              JSON.stringify(this.serviceLocation.holiday_opening_hours)
+            ) {
+              delete data.holiday_opening_hours;
+            }
+            // Remove the logo from the request if null, or delete if false.
+            if (data.image_file_id === null) {
+              delete data.image_file_id;
+            } else if (data.image_file_id === false) {
+              data.image_file_id = null;
+            }
           }
-          if (
-            JSON.stringify(data.regular_opening_hours) ===
-            JSON.stringify(this.serviceLocation.regular_opening_hours)
-          ) {
-            delete data.regular_opening_hours;
-          }
-          if (
-            JSON.stringify(data.holiday_opening_hours) ===
-            JSON.stringify(this.serviceLocation.holiday_opening_hours)
-          ) {
-            delete data.holiday_opening_hours;
-          }
-          // Remove the logo from the request if null, or delete if false.
-          if (data.image_file_id === null) {
-            delete data.image_file_id;
-          } else if (data.image_file_id === false) {
-            data.image_file_id = null;
+        );
+
+        const updateRequestId = response.id;
+        let next = {
+          name: 'service-locations-updated',
+          params: { serviceLocation: this.serviceLocation.id },
+        };
+
+        if (this.auth.isGlobalAdmin) {
+          try {
+            const { data } = await http.get(
+              `/update-requests/${updateRequestId}`
+            );
+            if (data.approved_at) {
+              next.name = 'service-locations-show';
+              next.query = { updated: true };
+            }
+          } catch (err) {
+            console.log(err);
           }
         }
-      );
-
-      this.$router.push({
-        name: "service-locations-updated",
-        params: { serviceLocation: this.serviceLocation.id }
-      });
-    }
-  },
-  created() {
-    this.fetchServiceLocation();
-  }
-};
+        this.$router.push(next);
+      },
+    },
+    created() {
+      this.fetchServiceLocation();
+    },
+  };
 </script>

--- a/src/views/service-locations/Edit.vue
+++ b/src/views/service-locations/Edit.vue
@@ -12,7 +12,7 @@
       <gov-back-link
         :to="{
           name: 'service-locations-show',
-          params: { serviceLocation: serviceLocation.id },
+          params: { serviceLocation: serviceLocation.id }
         }"
         >Back to service location</gov-back-link
       >
@@ -52,93 +52,93 @@
 </template>
 
 <script>
-  import Form from '@/classes/Form';
-  import ServiceLocationForm from '@/views/service-locations/forms/ServiceLocationForm';
-  import http from '@/http';
+import Form from "@/classes/Form";
+import ServiceLocationForm from "@/views/service-locations/forms/ServiceLocationForm";
+import http from "@/http";
 
-  export default {
-    name: 'EditServiceLocation',
-    components: { ServiceLocationForm },
-    data() {
-      return {
-        form: null,
-        serviceLocation: null,
-        loading: false,
-      };
+export default {
+  name: "EditServiceLocation",
+  components: { ServiceLocationForm },
+  data() {
+    return {
+      form: null,
+      serviceLocation: null,
+      loading: false
+    };
+  },
+  computed: {
+    updateButtonText() {
+      return this.auth.isGlobalAdmin ? "Update" : "Request update";
+    }
+  },
+  methods: {
+    async fetchServiceLocation() {
+      this.loading = true;
+      const response = await http.get(
+        `/service-locations/${this.$route.params.serviceLocation}`
+      );
+      this.serviceLocation = response.data.data;
+      this.form = new Form({
+        name: this.serviceLocation.name || "",
+        regular_opening_hours: this.serviceLocation.regular_opening_hours,
+        holiday_opening_hours: this.serviceLocation.holiday_opening_hours,
+        image_file_id: null
+      });
+      this.loading = false;
     },
-    computed: {
-      updateButtonText() {
-        return this.auth.isGlobalAdmin ? 'Update' : 'Request update';
-      },
-    },
-    methods: {
-      async fetchServiceLocation() {
-        this.loading = true;
-        const response = await http.get(
-          `/service-locations/${this.$route.params.serviceLocation}`
-        );
-        this.serviceLocation = response.data.data;
-        this.form = new Form({
-          name: this.serviceLocation.name || '',
-          regular_opening_hours: this.serviceLocation.regular_opening_hours,
-          holiday_opening_hours: this.serviceLocation.holiday_opening_hours,
-          image_file_id: null,
-        });
-        this.loading = false;
-      },
-      async onSubmit() {
-        const response = await this.form.put(
-          `/service-locations/${this.serviceLocation.id}`,
-          (config, data) => {
-            // Remove any unchanged values.
-            if (data.name === (this.serviceLocation.name || '')) {
-              delete data.name;
-            }
-            if (
-              JSON.stringify(data.regular_opening_hours) ===
-              JSON.stringify(this.serviceLocation.regular_opening_hours)
-            ) {
-              delete data.regular_opening_hours;
-            }
-            if (
-              JSON.stringify(data.holiday_opening_hours) ===
-              JSON.stringify(this.serviceLocation.holiday_opening_hours)
-            ) {
-              delete data.holiday_opening_hours;
-            }
-            // Remove the logo from the request if null, or delete if false.
-            if (data.image_file_id === null) {
-              delete data.image_file_id;
-            } else if (data.image_file_id === false) {
-              data.image_file_id = null;
-            }
+    async onSubmit() {
+      const response = await this.form.put(
+        `/service-locations/${this.serviceLocation.id}`,
+        (config, data) => {
+          // Remove any unchanged values.
+          if (data.name === (this.serviceLocation.name || "")) {
+            delete data.name;
           }
-        );
-
-        const updateRequestId = response.id;
-        let next = {
-          name: 'service-locations-updated',
-          params: { serviceLocation: this.serviceLocation.id },
-        };
-
-        if (this.auth.isGlobalAdmin) {
-          try {
-            const { data } = await http.get(
-              `/update-requests/${updateRequestId}`
-            );
-            if (data.approved_at) {
-              next.name = 'service-locations-show';
-              next.query = { updated: true };
-            }
-          } catch (err) {
-            console.log(err);
+          if (
+            JSON.stringify(data.regular_opening_hours) ===
+            JSON.stringify(this.serviceLocation.regular_opening_hours)
+          ) {
+            delete data.regular_opening_hours;
+          }
+          if (
+            JSON.stringify(data.holiday_opening_hours) ===
+            JSON.stringify(this.serviceLocation.holiday_opening_hours)
+          ) {
+            delete data.holiday_opening_hours;
+          }
+          // Remove the logo from the request if null, or delete if false.
+          if (data.image_file_id === null) {
+            delete data.image_file_id;
+          } else if (data.image_file_id === false) {
+            data.image_file_id = null;
           }
         }
-        this.$router.push(next);
-      },
-    },
-    created() {
-      this.fetchServiceLocation();
-    },
-  };
+      );
+
+      const updateRequestId = response.id;
+      let next = {
+        name: "service-locations-updated",
+        params: { serviceLocation: this.serviceLocation.id }
+      };
+
+      if (this.auth.isGlobalAdmin) {
+        try {
+          const { data } = await http.get(
+            `/update-requests/${updateRequestId}`
+          );
+          if (data.approved_at) {
+            next.name = "service-locations-show";
+            next.query = { updated: true };
+          }
+        } catch (err) {
+          console.log(err);
+        }
+      }
+      this.$router.push(next);
+    }
+  },
+  created() {
+    this.fetchServiceLocation();
+  }
+};
 </script>

--- a/src/views/service-locations/Show.vue
+++ b/src/views/service-locations/Show.vue
@@ -12,7 +12,7 @@
       <gov-back-link
         :to="{
           name: 'services-show-locations',
-          params: { service: serviceLocation.service_id },
+          params: { service: serviceLocation.service_id }
         }"
         >Back to service</gov-back-link
       >
@@ -22,7 +22,7 @@
             <gov-heading size="m">View service location</gov-heading>
 
             <gov-inset-text v-if="updated"
-              >Service Location {{ serviceLocation.name || '' }} has been
+              >Service Location {{ serviceLocation.name || "" }} has been
               updated</gov-inset-text
             >
 
@@ -51,7 +51,7 @@
             <gov-button
               :to="{
                 name: 'service-locations-edit',
-                params: { serviceLocation: serviceLocation.id },
+                params: { serviceLocation: serviceLocation.id }
               }"
             >
               Edit service location
@@ -64,39 +64,39 @@
 </template>
 
 <script>
-  import http from '@/http';
-  import ServiceLocationDetails from '@/views/service-locations/show/ServiceLocationDetails';
+import http from "@/http";
+import ServiceLocationDetails from "@/views/service-locations/show/ServiceLocationDetails";
 
-  export default {
-    name: 'ShowServiceLocation',
-    components: { ServiceLocationDetails },
-    data() {
-      return {
-        loading: false,
-        serviceLocation: null,
-        updated: false,
-      };
+export default {
+  name: "ShowServiceLocation",
+  components: { ServiceLocationDetails },
+  data() {
+    return {
+      loading: false,
+      serviceLocation: null,
+      updated: false
+    };
+  },
+  methods: {
+    async fetchServiceLocation() {
+      this.loading = true;
+      const response = await http.get(
+        `/service-locations/${this.$route.params.serviceLocation}`,
+        { params: { include: "location" } }
+      );
+      this.serviceLocation = response.data.data;
+      this.loading = false;
     },
-    methods: {
-      async fetchServiceLocation() {
-        this.loading = true;
-        const response = await http.get(
-          `/service-locations/${this.$route.params.serviceLocation}`,
-          { params: { include: 'location' } }
-        );
-        this.serviceLocation = response.data.data;
-        this.loading = false;
-      },
-      onDelete() {
-        this.$router.push({
-          name: 'services-show',
-          params: { service: this.serviceLocation.service_id },
-        });
-      },
-    },
-    created() {
-      this.updated = this.$route.query.updated || false;
-      this.fetchServiceLocation();
-    },
-  };
+    onDelete() {
+      this.$router.push({
+        name: "services-show",
+        params: { service: this.serviceLocation.service_id }
+      });
+    }
+  },
+  created() {
+    this.updated = this.$route.query.updated || false;
+    this.fetchServiceLocation();
+  }
+};
 </script>

--- a/src/views/service-locations/Show.vue
+++ b/src/views/service-locations/Show.vue
@@ -12,7 +12,7 @@
       <gov-back-link
         :to="{
           name: 'services-show-locations',
-          params: { service: serviceLocation.service_id }
+          params: { service: serviceLocation.service_id },
         }"
         >Back to service</gov-back-link
       >
@@ -20,6 +20,11 @@
         <gov-grid-row>
           <gov-grid-column width="two-thirds">
             <gov-heading size="m">View service location</gov-heading>
+
+            <gov-inset-text v-if="updated"
+              >Service Location {{ serviceLocation.name || '' }} has been
+              updated</gov-inset-text
+            >
 
             <service-location-details :service-location="serviceLocation" />
 
@@ -46,7 +51,7 @@
             <gov-button
               :to="{
                 name: 'service-locations-edit',
-                params: { serviceLocation: serviceLocation.id }
+                params: { serviceLocation: serviceLocation.id },
               }"
             >
               Edit service location
@@ -59,37 +64,39 @@
 </template>
 
 <script>
-import http from "@/http";
-import ServiceLocationDetails from "@/views/service-locations/show/ServiceLocationDetails";
+  import http from '@/http';
+  import ServiceLocationDetails from '@/views/service-locations/show/ServiceLocationDetails';
 
-export default {
-  name: "ShowServiceLocation",
-  components: { ServiceLocationDetails },
-  data() {
-    return {
-      loading: false,
-      serviceLocation: null
-    };
-  },
-  methods: {
-    async fetchServiceLocation() {
-      this.loading = true;
-      const response = await http.get(
-        `/service-locations/${this.$route.params.serviceLocation}`,
-        { params: { include: "location" } }
-      );
-      this.serviceLocation = response.data.data;
-      this.loading = false;
+  export default {
+    name: 'ShowServiceLocation',
+    components: { ServiceLocationDetails },
+    data() {
+      return {
+        loading: false,
+        serviceLocation: null,
+        updated: false,
+      };
     },
-    onDelete() {
-      this.$router.push({
-        name: "services-show",
-        params: { service: this.serviceLocation.service_id }
-      });
-    }
-  },
-  created() {
-    this.fetchServiceLocation();
-  }
-};
+    methods: {
+      async fetchServiceLocation() {
+        this.loading = true;
+        const response = await http.get(
+          `/service-locations/${this.$route.params.serviceLocation}`,
+          { params: { include: 'location' } }
+        );
+        this.serviceLocation = response.data.data;
+        this.loading = false;
+      },
+      onDelete() {
+        this.$router.push({
+          name: 'services-show',
+          params: { service: this.serviceLocation.service_id },
+        });
+      },
+    },
+    created() {
+      this.updated = this.$route.query.updated || false;
+      this.fetchServiceLocation();
+    },
+  };
 </script>

--- a/src/views/services/Edit.vue
+++ b/src/views/services/Edit.vue
@@ -200,7 +200,7 @@
                 :service="updateRequest.data"
                 :logo-data-uri="form.logo"
                 :gallery-items-data-uris="
-                  form.gallery_items.map(galleryItem => galleryItem.image)
+                  form.gallery_items.map((galleryItem) => galleryItem.image)
                 "
               />
 
@@ -212,9 +212,9 @@
               <gov-button v-if="form.$submitting" disabled type="submit"
                 >Requesting...</gov-button
               >
-              <gov-button v-else @click="onSubmit" type="submit"
-                >Request update</gov-button
-              >
+              <gov-button v-else @click="onSubmit" type="submit">{{
+                updateButtonText
+              }}</gov-button>
             </gov-grid-column>
           </gov-grid-row>
         </gov-main-wrapper>
@@ -224,328 +224,349 @@
 </template>
 
 <script>
-import Form from "@/classes/Form";
-import http from "@/http";
-import DetailsTab from "@/views/services/forms/DetailsTab";
-import DescriptionTab from "@/views/services/forms/DescriptionTab";
-import AdditionalInfoTab from "@/views/services/forms/AdditionalInfoTab";
-import UsefulInfoTab from "@/views/services/forms/UsefulInfoTab";
-import WhoForTab from "@/views/services/forms/WhoForTab";
-import ReferralTab from "@/views/services/forms/ReferralTab";
-import TaxonomiesTab from "@/views/services/forms/TaxonomiesTab";
-import ServiceDetails from "@/views/update-requests/show/ServiceDetails";
+  import Form from '@/classes/Form';
+  import http from '@/http';
+  import DetailsTab from '@/views/services/forms/DetailsTab';
+  import DescriptionTab from '@/views/services/forms/DescriptionTab';
+  import AdditionalInfoTab from '@/views/services/forms/AdditionalInfoTab';
+  import UsefulInfoTab from '@/views/services/forms/UsefulInfoTab';
+  import WhoForTab from '@/views/services/forms/WhoForTab';
+  import ReferralTab from '@/views/services/forms/ReferralTab';
+  import TaxonomiesTab from '@/views/services/forms/TaxonomiesTab';
+  import ServiceDetails from '@/views/update-requests/show/ServiceDetails';
 
-export default {
-  name: "EditService",
-  components: {
-    DetailsTab,
-    DescriptionTab,
-    AdditionalInfoTab,
-    UsefulInfoTab,
-    WhoForTab,
-    ReferralTab,
-    TaxonomiesTab,
-    ServiceDetails
-  },
-  data() {
-    return {
-      form: null,
-      tabs: [
-        { id: "details", heading: "Details", active: true },
-        { id: "additional-info", heading: "Additional info", active: false },
-        { id: "useful-info", heading: "Good to know", active: false },
-        { id: "who-for", heading: "Who is it for?", active: false },
-        { id: "taxonomies", heading: "Taxonomies", active: false },
-        { id: "description", heading: "Description", active: false },
-        { id: "referral", heading: "Referral", active: false }
-      ],
-      errors: {},
-      service: null,
-      loading: false,
-      updateRequest: null
-    };
-  },
-  computed: {
-    allowedTabs() {
-      if (!this.auth.isGlobalAdmin) {
-        const taxonomiesTabIndex = this.tabs.findIndex(
-          tab => tab.id === "taxonomies"
-        );
-        const tabs = this.tabs.slice();
-        tabs.splice(taxonomiesTabIndex, 1);
-
-        return tabs;
-      }
-
-      return this.tabs;
-    }
-  },
-  methods: {
-    async fetchService() {
-      this.loading = true;
-
-      const response = await http.get(
-        `/services/${this.$route.params.service}`
-      );
-      this.service = response.data.data;
-      this.form = new Form({
-        organisation_id: this.service.organisation_id,
-        name: this.service.name,
-        slug: this.service.slug,
-        type: this.service.type,
-        status: this.service.status,
-        intro: this.service.intro,
-        description: this.service.description,
-        wait_time: this.service.wait_time,
-        is_free: this.service.is_free,
-        fees_text: this.service.fees_text || "",
-        fees_url: this.service.fees_url || "",
-        testimonial: this.service.testimonial || "",
-        video_embed: this.service.video_embed || "",
-        url: this.service.url,
-        contact_name: this.service.contact_name || "",
-        contact_phone: this.service.contact_phone || "",
-        contact_email: this.service.contact_email || "",
-        show_referral_disclaimer: this.service.show_referral_disclaimer,
-        referral_method: this.service.referral_method,
-        referral_button_text: this.service.referral_button_text || "",
-        referral_email: this.service.referral_email || "",
-        referral_url: this.service.referral_url || "",
-        criteria: {
-          age_group: this.service.criteria.age_group || "",
-          disability: this.service.criteria.disability || "",
-          employment: this.service.criteria.employment || "",
-          gender: this.service.criteria.gender || "",
-          housing: this.service.criteria.housing || "",
-          income: this.service.criteria.income || "",
-          language: this.service.criteria.language || "",
-          other: this.service.criteria.other || ""
-        },
-        useful_infos: this.service.useful_infos,
-        offerings: this.service.offerings,
-        social_medias: this.service.social_medias,
-        gallery_items: this.service.gallery_items.map(galleryItem => ({
-          file_id: galleryItem.file_id,
-          image: null
-        })),
-        category_taxonomies: this.service.category_taxonomies.map(
-          taxonomy => taxonomy.id
-        ),
-        logo_file_id: null,
-        logo: null
-      });
-
-      this.loading = false;
+  export default {
+    name: 'EditService',
+    components: {
+      DetailsTab,
+      DescriptionTab,
+      AdditionalInfoTab,
+      UsefulInfoTab,
+      WhoForTab,
+      ReferralTab,
+      TaxonomiesTab,
+      ServiceDetails,
     },
-    async onSubmit(preview = false) {
-      const response = await this.form.put(
-        `/services/${this.service.id}`,
-        (config, data) => {
-          // Append preview mode if enabled.
-          data.preview = preview;
+    data() {
+      return {
+        form: null,
+        tabs: [
+          { id: 'details', heading: 'Details', active: true },
+          { id: 'additional-info', heading: 'Additional info', active: false },
+          { id: 'useful-info', heading: 'Good to know', active: false },
+          { id: 'who-for', heading: 'Who is it for?', active: false },
+          { id: 'taxonomies', heading: 'Taxonomies', active: false },
+          { id: 'description', heading: 'Description', active: false },
+          { id: 'referral', heading: 'Referral', active: false },
+        ],
+        errors: {},
+        service: null,
+        loading: false,
+        updateRequest: null,
+      };
+    },
+    computed: {
+      allowedTabs() {
+        if (!this.auth.isGlobalAdmin) {
+          const taxonomiesTabIndex = this.tabs.findIndex(
+            (tab) => tab.id === 'taxonomies'
+          );
+          const tabs = this.tabs.slice();
+          tabs.splice(taxonomiesTabIndex, 1);
 
-          // Remove any unchanged values.
-          if (data.organisation_id === this.service.organisation_id) {
-            delete data.organisation_id;
-          }
-          if (data.name === this.service.name) {
-            delete data.name;
-          }
-          if (data.slug === this.service.slug) {
-            delete data.slug;
-          }
-          if (data.type === this.service.type) {
-            delete data.type;
-          }
-          if (data.status === this.service.status) {
-            delete data.status;
-          }
-          if (data.intro === this.service.intro) {
-            delete data.intro;
-          }
-          if (data.description === this.service.description) {
-            delete data.description;
-          }
-          if (data.wait_time === this.service.wait_time) {
-            delete data.wait_time;
-          }
-          if (data.is_free === this.service.is_free) {
-            delete data.is_free;
-          }
-          if (data.fees_text === (this.service.fees_text || "")) {
-            delete data.fees_text;
-          }
-          if (data.fees_url === (this.service.fees_url || "")) {
-            delete data.fees_url;
-          }
-          if (data.testimonial === (this.service.testimonial || "")) {
-            delete data.testimonial;
-          }
-          if (data.video_embed === (this.service.video_embed || "")) {
-            delete data.video_embed;
-          }
-          if (data.url === this.service.url) {
-            delete data.url;
-          }
-          if (data.contact_name === (this.service.contact_name || "")) {
-            delete data.contact_name;
-          }
-          if (data.contact_phone === (this.service.contact_phone || "")) {
-            delete data.contact_phone;
-          }
-          if (data.contact_email === (this.service.contact_email || "")) {
-            delete data.contact_email;
-          }
-          if (
-            data.show_referral_disclaimer ===
-            this.service.show_referral_disclaimer
-          ) {
-            delete data.show_referral_disclaimer;
-          }
-          if (data.referral_method === this.service.referral_method) {
-            delete data.referral_method;
-          }
-          if (
-            data.referral_button_text ===
-            (this.service.referral_button_text || "")
-          ) {
-            delete data.referral_button_text;
-          }
-          if (data.referral_email === (this.service.referral_email || "")) {
-            delete data.referral_email;
-          }
-          if (data.referral_url === (this.service.referral_url || "")) {
-            delete data.referral_url;
-          }
-          if (
-            data.criteria.age_group === (this.service.criteria.age_group || "")
-          ) {
-            delete data.criteria.age_group;
-          }
-          if (
-            data.criteria.disability ===
-            (this.service.criteria.disability || "")
-          ) {
-            delete data.criteria.disability;
-          }
-          if (
-            data.criteria.employment ===
-            (this.service.criteria.employment || "")
-          ) {
-            delete data.criteria.employment;
-          }
-          if (data.criteria.gender === (this.service.criteria.gender || "")) {
-            delete data.criteria.gender;
-          }
-          if (data.criteria.housing === (this.service.criteria.housing || "")) {
-            delete data.criteria.housing;
-          }
-          if (data.criteria.income === (this.service.criteria.income || "")) {
-            delete data.criteria.income;
-          }
-          if (
-            data.criteria.language === (this.service.criteria.language || "")
-          ) {
-            delete data.criteria.language;
-          }
-          if (data.criteria.other === (this.service.criteria.other || "")) {
-            delete data.criteria.other;
-          }
-          if (Object.keys(data.criteria).length === 0) {
-            delete data.criteria;
-          }
-          if (
-            JSON.stringify(data.useful_infos) ===
-            JSON.stringify(this.service.useful_infos)
-          ) {
-            delete data.useful_infos;
-          }
-          if (
-            JSON.stringify(data.offerings) ===
-            JSON.stringify(this.service.offerings)
-          ) {
-            delete data.offerings;
-          }
-          if (
-            JSON.stringify(data.social_medias) ===
-            JSON.stringify(this.service.social_medias)
-          ) {
-            delete data.social_medias;
-          }
-          if (
-            JSON.stringify(data.category_taxonomies) ===
-            JSON.stringify(
-              this.service.category_taxonomies.map(taxonomy => taxonomy.id)
-            )
-          ) {
-            delete data.category_taxonomies;
-          }
+          return tabs;
+        }
 
-          // Remove the logo from the request if null, or delete if false.
-          if (data.logo_file_id === null) {
-            delete data.logo_file_id;
-          } else if (data.logo_file_id === false) {
-            data.logo_file_id = null;
-          }
+        return this.tabs;
+      },
+      updateButtonText() {
+        return this.auth.isGlobalAdmin ? 'Update' : 'Request update';
+      },
+    },
+    methods: {
+      async fetchService() {
+        this.loading = true;
 
-          // Remove the gallery items from the request if null, or delete if false.
-          if (
-            JSON.stringify(
-              data.gallery_items.map(galleryItem => ({
-                file_id: galleryItem.file_id
-              }))
-            ) ===
-            JSON.stringify(
-              this.service.gallery_items.map(galleryItem => ({
-                file_id: galleryItem.file_id
-              }))
-            )
-          ) {
-            delete data.gallery_items;
+        const response = await http.get(
+          `/services/${this.$route.params.service}`
+        );
+        this.service = response.data.data;
+        this.form = new Form({
+          organisation_id: this.service.organisation_id,
+          name: this.service.name,
+          slug: this.service.slug,
+          type: this.service.type,
+          status: this.service.status,
+          intro: this.service.intro,
+          description: this.service.description,
+          wait_time: this.service.wait_time,
+          is_free: this.service.is_free,
+          fees_text: this.service.fees_text || '',
+          fees_url: this.service.fees_url || '',
+          testimonial: this.service.testimonial || '',
+          video_embed: this.service.video_embed || '',
+          url: this.service.url,
+          contact_name: this.service.contact_name || '',
+          contact_phone: this.service.contact_phone || '',
+          contact_email: this.service.contact_email || '',
+          show_referral_disclaimer: this.service.show_referral_disclaimer,
+          referral_method: this.service.referral_method,
+          referral_button_text: this.service.referral_button_text || '',
+          referral_email: this.service.referral_email || '',
+          referral_url: this.service.referral_url || '',
+          criteria: {
+            age_group: this.service.criteria.age_group || '',
+            disability: this.service.criteria.disability || '',
+            employment: this.service.criteria.employment || '',
+            gender: this.service.criteria.gender || '',
+            housing: this.service.criteria.housing || '',
+            income: this.service.criteria.income || '',
+            language: this.service.criteria.language || '',
+            other: this.service.criteria.other || '',
+          },
+          useful_infos: this.service.useful_infos,
+          offerings: this.service.offerings,
+          social_medias: this.service.social_medias,
+          gallery_items: this.service.gallery_items.map((galleryItem) => ({
+            file_id: galleryItem.file_id,
+            image: null,
+          })),
+          category_taxonomies: this.service.category_taxonomies.map(
+            (taxonomy) => taxonomy.id
+          ),
+          logo_file_id: null,
+          logo: null,
+        });
+
+        this.loading = false;
+      },
+      async onSubmit(preview = false) {
+        const response = await this.form.put(
+          `/services/${this.service.id}`,
+          (config, data) => {
+            // Append preview mode if enabled.
+            data.preview = preview;
+
+            // Remove any unchanged values.
+            if (data.organisation_id === this.service.organisation_id) {
+              delete data.organisation_id;
+            }
+            if (data.name === this.service.name) {
+              delete data.name;
+            }
+            if (data.slug === this.service.slug) {
+              delete data.slug;
+            }
+            if (data.type === this.service.type) {
+              delete data.type;
+            }
+            if (data.status === this.service.status) {
+              delete data.status;
+            }
+            if (data.intro === this.service.intro) {
+              delete data.intro;
+            }
+            if (data.description === this.service.description) {
+              delete data.description;
+            }
+            if (data.wait_time === this.service.wait_time) {
+              delete data.wait_time;
+            }
+            if (data.is_free === this.service.is_free) {
+              delete data.is_free;
+            }
+            if (data.fees_text === (this.service.fees_text || '')) {
+              delete data.fees_text;
+            }
+            if (data.fees_url === (this.service.fees_url || '')) {
+              delete data.fees_url;
+            }
+            if (data.testimonial === (this.service.testimonial || '')) {
+              delete data.testimonial;
+            }
+            if (data.video_embed === (this.service.video_embed || '')) {
+              delete data.video_embed;
+            }
+            if (data.url === this.service.url) {
+              delete data.url;
+            }
+            if (data.contact_name === (this.service.contact_name || '')) {
+              delete data.contact_name;
+            }
+            if (data.contact_phone === (this.service.contact_phone || '')) {
+              delete data.contact_phone;
+            }
+            if (data.contact_email === (this.service.contact_email || '')) {
+              delete data.contact_email;
+            }
+            if (
+              data.show_referral_disclaimer ===
+              this.service.show_referral_disclaimer
+            ) {
+              delete data.show_referral_disclaimer;
+            }
+            if (data.referral_method === this.service.referral_method) {
+              delete data.referral_method;
+            }
+            if (
+              data.referral_button_text ===
+              (this.service.referral_button_text || '')
+            ) {
+              delete data.referral_button_text;
+            }
+            if (data.referral_email === (this.service.referral_email || '')) {
+              delete data.referral_email;
+            }
+            if (data.referral_url === (this.service.referral_url || '')) {
+              delete data.referral_url;
+            }
+            if (
+              data.criteria.age_group ===
+              (this.service.criteria.age_group || '')
+            ) {
+              delete data.criteria.age_group;
+            }
+            if (
+              data.criteria.disability ===
+              (this.service.criteria.disability || '')
+            ) {
+              delete data.criteria.disability;
+            }
+            if (
+              data.criteria.employment ===
+              (this.service.criteria.employment || '')
+            ) {
+              delete data.criteria.employment;
+            }
+            if (data.criteria.gender === (this.service.criteria.gender || '')) {
+              delete data.criteria.gender;
+            }
+            if (
+              data.criteria.housing === (this.service.criteria.housing || '')
+            ) {
+              delete data.criteria.housing;
+            }
+            if (data.criteria.income === (this.service.criteria.income || '')) {
+              delete data.criteria.income;
+            }
+            if (
+              data.criteria.language === (this.service.criteria.language || '')
+            ) {
+              delete data.criteria.language;
+            }
+            if (data.criteria.other === (this.service.criteria.other || '')) {
+              delete data.criteria.other;
+            }
+            if (Object.keys(data.criteria).length === 0) {
+              delete data.criteria;
+            }
+            if (
+              JSON.stringify(data.useful_infos) ===
+              JSON.stringify(this.service.useful_infos)
+            ) {
+              delete data.useful_infos;
+            }
+            if (
+              JSON.stringify(data.offerings) ===
+              JSON.stringify(this.service.offerings)
+            ) {
+              delete data.offerings;
+            }
+            if (
+              JSON.stringify(data.social_medias) ===
+              JSON.stringify(this.service.social_medias)
+            ) {
+              delete data.social_medias;
+            }
+            if (
+              JSON.stringify(data.category_taxonomies) ===
+              JSON.stringify(
+                this.service.category_taxonomies.map((taxonomy) => taxonomy.id)
+              )
+            ) {
+              delete data.category_taxonomies;
+            }
+
+            // Remove the logo from the request if null, or delete if false.
+            if (data.logo_file_id === null) {
+              delete data.logo_file_id;
+            } else if (data.logo_file_id === false) {
+              data.logo_file_id = null;
+            }
+
+            // Remove the gallery items from the request if null, or delete if false.
+            if (
+              JSON.stringify(
+                data.gallery_items.map((galleryItem) => ({
+                  file_id: galleryItem.file_id,
+                }))
+              ) ===
+              JSON.stringify(
+                this.service.gallery_items.map((galleryItem) => ({
+                  file_id: galleryItem.file_id,
+                }))
+              )
+            ) {
+              delete data.gallery_items;
+            }
+          }
+        );
+
+        // Return the response if only a preview.
+        if (preview) {
+          response.data.id = this.service.id;
+          return response;
+        }
+
+        const updateRequestId = response.id;
+        let next = {
+          name: 'services-updated',
+          params: { service: this.service.id },
+        };
+
+        if (this.auth.isGlobalAdmin) {
+          try {
+            const { data } = await http.get(
+              `/update-requests/${updateRequestId}`
+            );
+            if (data.approved_at) {
+              next.name = 'services-show';
+              next.query = { updated: true };
+            }
+          } catch (err) {
+            console.log(err);
           }
         }
-      );
+        this.$router.push(next);
+      },
+      async onPreview() {
+        this.updateRequest = await this.onSubmit(true);
+      },
+      onTabChange({ index }) {
+        this.tabs.forEach((tab) => (tab.active = false));
+        const tabId = this.allowedTabs[index].id;
+        this.tabs.find((tab) => tab.id === tabId).active = true;
+      },
+      onNext() {
+        const currentTabIndex = this.allowedTabs.findIndex(
+          (tab) => tab.active === true
+        );
+        this.tabs.forEach((tab) => (tab.active = false));
+        const newTabId = this.allowedTabs[currentTabIndex + 1].id;
+        this.tabs.find((tab) => tab.id === newTabId).active = true;
+        this.scrollToTop();
+      },
+      scrollToTop() {
+        document.getElementById('main-content').scrollIntoView();
+      },
+      isTabActive(id) {
+        const tab = this.allowedTabs.find((tab) => tab.id === id);
 
-      // Return the response if only a preview.
-      if (preview) {
-        response.data.id = this.service.id;
-        return response;
-      }
-
-      // Otherwise, forward the user to the service page.
-      this.$router.push({
-        name: "services-updated",
-        params: { service: this.service.id }
-      });
+        return tab === undefined ? false : tab.active;
+      },
     },
-    async onPreview() {
-      this.updateRequest = await this.onSubmit(true);
+    created() {
+      this.fetchService();
     },
-    onTabChange({ index }) {
-      this.tabs.forEach(tab => (tab.active = false));
-      const tabId = this.allowedTabs[index].id;
-      this.tabs.find(tab => tab.id === tabId).active = true;
-    },
-    onNext() {
-      const currentTabIndex = this.allowedTabs.findIndex(
-        tab => tab.active === true
-      );
-      this.tabs.forEach(tab => (tab.active = false));
-      const newTabId = this.allowedTabs[currentTabIndex + 1].id;
-      this.tabs.find(tab => tab.id === newTabId).active = true;
-      this.scrollToTop();
-    },
-    scrollToTop() {
-      document.getElementById("main-content").scrollIntoView();
-    },
-    isTabActive(id) {
-      const tab = this.allowedTabs.find(tab => tab.id === id);
-
-      return tab === undefined ? false : tab.active;
-    }
-  },
-  created() {
-    this.fetchService();
-  }
-};
+  };
 </script>

--- a/src/views/services/Edit.vue
+++ b/src/views/services/Edit.vue
@@ -200,7 +200,7 @@
                 :service="updateRequest.data"
                 :logo-data-uri="form.logo"
                 :gallery-items-data-uris="
-                  form.gallery_items.map((galleryItem) => galleryItem.image)
+                  form.gallery_items.map(galleryItem => galleryItem.image)
                 "
               />
 
@@ -224,349 +224,346 @@
 </template>
 
 <script>
-  import Form from '@/classes/Form';
-  import http from '@/http';
-  import DetailsTab from '@/views/services/forms/DetailsTab';
-  import DescriptionTab from '@/views/services/forms/DescriptionTab';
-  import AdditionalInfoTab from '@/views/services/forms/AdditionalInfoTab';
-  import UsefulInfoTab from '@/views/services/forms/UsefulInfoTab';
-  import WhoForTab from '@/views/services/forms/WhoForTab';
-  import ReferralTab from '@/views/services/forms/ReferralTab';
-  import TaxonomiesTab from '@/views/services/forms/TaxonomiesTab';
-  import ServiceDetails from '@/views/update-requests/show/ServiceDetails';
+import Form from "@/classes/Form";
+import http from "@/http";
+import DetailsTab from "@/views/services/forms/DetailsTab";
+import DescriptionTab from "@/views/services/forms/DescriptionTab";
+import AdditionalInfoTab from "@/views/services/forms/AdditionalInfoTab";
+import UsefulInfoTab from "@/views/services/forms/UsefulInfoTab";
+import WhoForTab from "@/views/services/forms/WhoForTab";
+import ReferralTab from "@/views/services/forms/ReferralTab";
+import TaxonomiesTab from "@/views/services/forms/TaxonomiesTab";
+import ServiceDetails from "@/views/update-requests/show/ServiceDetails";
 
-  export default {
-    name: 'EditService',
-    components: {
-      DetailsTab,
-      DescriptionTab,
-      AdditionalInfoTab,
-      UsefulInfoTab,
-      WhoForTab,
-      ReferralTab,
-      TaxonomiesTab,
-      ServiceDetails,
+export default {
+  name: "EditService",
+  components: {
+    DetailsTab,
+    DescriptionTab,
+    AdditionalInfoTab,
+    UsefulInfoTab,
+    WhoForTab,
+    ReferralTab,
+    TaxonomiesTab,
+    ServiceDetails
+  },
+  data() {
+    return {
+      form: null,
+      tabs: [
+        { id: "details", heading: "Details", active: true },
+        { id: "additional-info", heading: "Additional info", active: false },
+        { id: "useful-info", heading: "Good to know", active: false },
+        { id: "who-for", heading: "Who is it for?", active: false },
+        { id: "taxonomies", heading: "Taxonomies", active: false },
+        { id: "description", heading: "Description", active: false },
+        { id: "referral", heading: "Referral", active: false }
+      ],
+      errors: {},
+      service: null,
+      loading: false,
+      updateRequest: null
+    };
+  },
+  computed: {
+    allowedTabs() {
+      if (!this.auth.isGlobalAdmin) {
+        const taxonomiesTabIndex = this.tabs.findIndex(
+          tab => tab.id === "taxonomies"
+        );
+        const tabs = this.tabs.slice();
+        tabs.splice(taxonomiesTabIndex, 1);
+
+        return tabs;
+      }
+
+      return this.tabs;
     },
-    data() {
-      return {
-        form: null,
-        tabs: [
-          { id: 'details', heading: 'Details', active: true },
-          { id: 'additional-info', heading: 'Additional info', active: false },
-          { id: 'useful-info', heading: 'Good to know', active: false },
-          { id: 'who-for', heading: 'Who is it for?', active: false },
-          { id: 'taxonomies', heading: 'Taxonomies', active: false },
-          { id: 'description', heading: 'Description', active: false },
-          { id: 'referral', heading: 'Referral', active: false },
-        ],
-        errors: {},
-        service: null,
-        loading: false,
-        updateRequest: null,
+    updateButtonText() {
+      return this.auth.isGlobalAdmin ? "Update" : "Request update";
+    }
+  },
+  methods: {
+    async fetchService() {
+      this.loading = true;
+
+      const response = await http.get(
+        `/services/${this.$route.params.service}`
+      );
+      this.service = response.data.data;
+      this.form = new Form({
+        organisation_id: this.service.organisation_id,
+        name: this.service.name,
+        slug: this.service.slug,
+        type: this.service.type,
+        status: this.service.status,
+        intro: this.service.intro,
+        description: this.service.description,
+        wait_time: this.service.wait_time,
+        is_free: this.service.is_free,
+        fees_text: this.service.fees_text || "",
+        fees_url: this.service.fees_url || "",
+        testimonial: this.service.testimonial || "",
+        video_embed: this.service.video_embed || "",
+        url: this.service.url,
+        contact_name: this.service.contact_name || "",
+        contact_phone: this.service.contact_phone || "",
+        contact_email: this.service.contact_email || "",
+        show_referral_disclaimer: this.service.show_referral_disclaimer,
+        referral_method: this.service.referral_method,
+        referral_button_text: this.service.referral_button_text || "",
+        referral_email: this.service.referral_email || "",
+        referral_url: this.service.referral_url || "",
+        criteria: {
+          age_group: this.service.criteria.age_group || "",
+          disability: this.service.criteria.disability || "",
+          employment: this.service.criteria.employment || "",
+          gender: this.service.criteria.gender || "",
+          housing: this.service.criteria.housing || "",
+          income: this.service.criteria.income || "",
+          language: this.service.criteria.language || "",
+          other: this.service.criteria.other || ""
+        },
+        useful_infos: this.service.useful_infos,
+        offerings: this.service.offerings,
+        social_medias: this.service.social_medias,
+        gallery_items: this.service.gallery_items.map(galleryItem => ({
+          file_id: galleryItem.file_id,
+          image: null
+        })),
+        category_taxonomies: this.service.category_taxonomies.map(
+          taxonomy => taxonomy.id
+        ),
+        logo_file_id: null,
+        logo: null
+      });
+
+      this.loading = false;
+    },
+    async onSubmit(preview = false) {
+      const response = await this.form.put(
+        `/services/${this.service.id}`,
+        (config, data) => {
+          // Append preview mode if enabled.
+          data.preview = preview;
+
+          // Remove any unchanged values.
+          if (data.organisation_id === this.service.organisation_id) {
+            delete data.organisation_id;
+          }
+          if (data.name === this.service.name) {
+            delete data.name;
+          }
+          if (data.slug === this.service.slug) {
+            delete data.slug;
+          }
+          if (data.type === this.service.type) {
+            delete data.type;
+          }
+          if (data.status === this.service.status) {
+            delete data.status;
+          }
+          if (data.intro === this.service.intro) {
+            delete data.intro;
+          }
+          if (data.description === this.service.description) {
+            delete data.description;
+          }
+          if (data.wait_time === this.service.wait_time) {
+            delete data.wait_time;
+          }
+          if (data.is_free === this.service.is_free) {
+            delete data.is_free;
+          }
+          if (data.fees_text === (this.service.fees_text || "")) {
+            delete data.fees_text;
+          }
+          if (data.fees_url === (this.service.fees_url || "")) {
+            delete data.fees_url;
+          }
+          if (data.testimonial === (this.service.testimonial || "")) {
+            delete data.testimonial;
+          }
+          if (data.video_embed === (this.service.video_embed || "")) {
+            delete data.video_embed;
+          }
+          if (data.url === this.service.url) {
+            delete data.url;
+          }
+          if (data.contact_name === (this.service.contact_name || "")) {
+            delete data.contact_name;
+          }
+          if (data.contact_phone === (this.service.contact_phone || "")) {
+            delete data.contact_phone;
+          }
+          if (data.contact_email === (this.service.contact_email || "")) {
+            delete data.contact_email;
+          }
+          if (
+            data.show_referral_disclaimer ===
+            this.service.show_referral_disclaimer
+          ) {
+            delete data.show_referral_disclaimer;
+          }
+          if (data.referral_method === this.service.referral_method) {
+            delete data.referral_method;
+          }
+          if (
+            data.referral_button_text ===
+            (this.service.referral_button_text || "")
+          ) {
+            delete data.referral_button_text;
+          }
+          if (data.referral_email === (this.service.referral_email || "")) {
+            delete data.referral_email;
+          }
+          if (data.referral_url === (this.service.referral_url || "")) {
+            delete data.referral_url;
+          }
+          if (
+            data.criteria.age_group === (this.service.criteria.age_group || "")
+          ) {
+            delete data.criteria.age_group;
+          }
+          if (
+            data.criteria.disability ===
+            (this.service.criteria.disability || "")
+          ) {
+            delete data.criteria.disability;
+          }
+          if (
+            data.criteria.employment ===
+            (this.service.criteria.employment || "")
+          ) {
+            delete data.criteria.employment;
+          }
+          if (data.criteria.gender === (this.service.criteria.gender || "")) {
+            delete data.criteria.gender;
+          }
+          if (data.criteria.housing === (this.service.criteria.housing || "")) {
+            delete data.criteria.housing;
+          }
+          if (data.criteria.income === (this.service.criteria.income || "")) {
+            delete data.criteria.income;
+          }
+          if (
+            data.criteria.language === (this.service.criteria.language || "")
+          ) {
+            delete data.criteria.language;
+          }
+          if (data.criteria.other === (this.service.criteria.other || "")) {
+            delete data.criteria.other;
+          }
+          if (Object.keys(data.criteria).length === 0) {
+            delete data.criteria;
+          }
+          if (
+            JSON.stringify(data.useful_infos) ===
+            JSON.stringify(this.service.useful_infos)
+          ) {
+            delete data.useful_infos;
+          }
+          if (
+            JSON.stringify(data.offerings) ===
+            JSON.stringify(this.service.offerings)
+          ) {
+            delete data.offerings;
+          }
+          if (
+            JSON.stringify(data.social_medias) ===
+            JSON.stringify(this.service.social_medias)
+          ) {
+            delete data.social_medias;
+          }
+          if (
+            JSON.stringify(data.category_taxonomies) ===
+            JSON.stringify(
+              this.service.category_taxonomies.map(taxonomy => taxonomy.id)
+            )
+          ) {
+            delete data.category_taxonomies;
+          }
+
+          // Remove the logo from the request if null, or delete if false.
+          if (data.logo_file_id === null) {
+            delete data.logo_file_id;
+          } else if (data.logo_file_id === false) {
+            data.logo_file_id = null;
+          }
+
+          // Remove the gallery items from the request if null, or delete if false.
+          if (
+            JSON.stringify(
+              data.gallery_items.map(galleryItem => ({
+                file_id: galleryItem.file_id
+              }))
+            ) ===
+            JSON.stringify(
+              this.service.gallery_items.map(galleryItem => ({
+                file_id: galleryItem.file_id
+              }))
+            )
+          ) {
+            delete data.gallery_items;
+          }
+        }
+      );
+
+      // Return the response if only a preview.
+      if (preview) {
+        response.data.id = this.service.id;
+        return response;
+      }
+
+      const updateRequestId = response.id;
+      let next = {
+        name: "services-updated",
+        params: { service: this.service.id }
       };
-    },
-    computed: {
-      allowedTabs() {
-        if (!this.auth.isGlobalAdmin) {
-          const taxonomiesTabIndex = this.tabs.findIndex(
-            (tab) => tab.id === 'taxonomies'
+
+      if (this.auth.isGlobalAdmin) {
+        try {
+          const { data } = await http.get(
+            `/update-requests/${updateRequestId}`
           );
-          const tabs = this.tabs.slice();
-          tabs.splice(taxonomiesTabIndex, 1);
-
-          return tabs;
-        }
-
-        return this.tabs;
-      },
-      updateButtonText() {
-        return this.auth.isGlobalAdmin ? 'Update' : 'Request update';
-      },
-    },
-    methods: {
-      async fetchService() {
-        this.loading = true;
-
-        const response = await http.get(
-          `/services/${this.$route.params.service}`
-        );
-        this.service = response.data.data;
-        this.form = new Form({
-          organisation_id: this.service.organisation_id,
-          name: this.service.name,
-          slug: this.service.slug,
-          type: this.service.type,
-          status: this.service.status,
-          intro: this.service.intro,
-          description: this.service.description,
-          wait_time: this.service.wait_time,
-          is_free: this.service.is_free,
-          fees_text: this.service.fees_text || '',
-          fees_url: this.service.fees_url || '',
-          testimonial: this.service.testimonial || '',
-          video_embed: this.service.video_embed || '',
-          url: this.service.url,
-          contact_name: this.service.contact_name || '',
-          contact_phone: this.service.contact_phone || '',
-          contact_email: this.service.contact_email || '',
-          show_referral_disclaimer: this.service.show_referral_disclaimer,
-          referral_method: this.service.referral_method,
-          referral_button_text: this.service.referral_button_text || '',
-          referral_email: this.service.referral_email || '',
-          referral_url: this.service.referral_url || '',
-          criteria: {
-            age_group: this.service.criteria.age_group || '',
-            disability: this.service.criteria.disability || '',
-            employment: this.service.criteria.employment || '',
-            gender: this.service.criteria.gender || '',
-            housing: this.service.criteria.housing || '',
-            income: this.service.criteria.income || '',
-            language: this.service.criteria.language || '',
-            other: this.service.criteria.other || '',
-          },
-          useful_infos: this.service.useful_infos,
-          offerings: this.service.offerings,
-          social_medias: this.service.social_medias,
-          gallery_items: this.service.gallery_items.map((galleryItem) => ({
-            file_id: galleryItem.file_id,
-            image: null,
-          })),
-          category_taxonomies: this.service.category_taxonomies.map(
-            (taxonomy) => taxonomy.id
-          ),
-          logo_file_id: null,
-          logo: null,
-        });
-
-        this.loading = false;
-      },
-      async onSubmit(preview = false) {
-        const response = await this.form.put(
-          `/services/${this.service.id}`,
-          (config, data) => {
-            // Append preview mode if enabled.
-            data.preview = preview;
-
-            // Remove any unchanged values.
-            if (data.organisation_id === this.service.organisation_id) {
-              delete data.organisation_id;
-            }
-            if (data.name === this.service.name) {
-              delete data.name;
-            }
-            if (data.slug === this.service.slug) {
-              delete data.slug;
-            }
-            if (data.type === this.service.type) {
-              delete data.type;
-            }
-            if (data.status === this.service.status) {
-              delete data.status;
-            }
-            if (data.intro === this.service.intro) {
-              delete data.intro;
-            }
-            if (data.description === this.service.description) {
-              delete data.description;
-            }
-            if (data.wait_time === this.service.wait_time) {
-              delete data.wait_time;
-            }
-            if (data.is_free === this.service.is_free) {
-              delete data.is_free;
-            }
-            if (data.fees_text === (this.service.fees_text || '')) {
-              delete data.fees_text;
-            }
-            if (data.fees_url === (this.service.fees_url || '')) {
-              delete data.fees_url;
-            }
-            if (data.testimonial === (this.service.testimonial || '')) {
-              delete data.testimonial;
-            }
-            if (data.video_embed === (this.service.video_embed || '')) {
-              delete data.video_embed;
-            }
-            if (data.url === this.service.url) {
-              delete data.url;
-            }
-            if (data.contact_name === (this.service.contact_name || '')) {
-              delete data.contact_name;
-            }
-            if (data.contact_phone === (this.service.contact_phone || '')) {
-              delete data.contact_phone;
-            }
-            if (data.contact_email === (this.service.contact_email || '')) {
-              delete data.contact_email;
-            }
-            if (
-              data.show_referral_disclaimer ===
-              this.service.show_referral_disclaimer
-            ) {
-              delete data.show_referral_disclaimer;
-            }
-            if (data.referral_method === this.service.referral_method) {
-              delete data.referral_method;
-            }
-            if (
-              data.referral_button_text ===
-              (this.service.referral_button_text || '')
-            ) {
-              delete data.referral_button_text;
-            }
-            if (data.referral_email === (this.service.referral_email || '')) {
-              delete data.referral_email;
-            }
-            if (data.referral_url === (this.service.referral_url || '')) {
-              delete data.referral_url;
-            }
-            if (
-              data.criteria.age_group ===
-              (this.service.criteria.age_group || '')
-            ) {
-              delete data.criteria.age_group;
-            }
-            if (
-              data.criteria.disability ===
-              (this.service.criteria.disability || '')
-            ) {
-              delete data.criteria.disability;
-            }
-            if (
-              data.criteria.employment ===
-              (this.service.criteria.employment || '')
-            ) {
-              delete data.criteria.employment;
-            }
-            if (data.criteria.gender === (this.service.criteria.gender || '')) {
-              delete data.criteria.gender;
-            }
-            if (
-              data.criteria.housing === (this.service.criteria.housing || '')
-            ) {
-              delete data.criteria.housing;
-            }
-            if (data.criteria.income === (this.service.criteria.income || '')) {
-              delete data.criteria.income;
-            }
-            if (
-              data.criteria.language === (this.service.criteria.language || '')
-            ) {
-              delete data.criteria.language;
-            }
-            if (data.criteria.other === (this.service.criteria.other || '')) {
-              delete data.criteria.other;
-            }
-            if (Object.keys(data.criteria).length === 0) {
-              delete data.criteria;
-            }
-            if (
-              JSON.stringify(data.useful_infos) ===
-              JSON.stringify(this.service.useful_infos)
-            ) {
-              delete data.useful_infos;
-            }
-            if (
-              JSON.stringify(data.offerings) ===
-              JSON.stringify(this.service.offerings)
-            ) {
-              delete data.offerings;
-            }
-            if (
-              JSON.stringify(data.social_medias) ===
-              JSON.stringify(this.service.social_medias)
-            ) {
-              delete data.social_medias;
-            }
-            if (
-              JSON.stringify(data.category_taxonomies) ===
-              JSON.stringify(
-                this.service.category_taxonomies.map((taxonomy) => taxonomy.id)
-              )
-            ) {
-              delete data.category_taxonomies;
-            }
-
-            // Remove the logo from the request if null, or delete if false.
-            if (data.logo_file_id === null) {
-              delete data.logo_file_id;
-            } else if (data.logo_file_id === false) {
-              data.logo_file_id = null;
-            }
-
-            // Remove the gallery items from the request if null, or delete if false.
-            if (
-              JSON.stringify(
-                data.gallery_items.map((galleryItem) => ({
-                  file_id: galleryItem.file_id,
-                }))
-              ) ===
-              JSON.stringify(
-                this.service.gallery_items.map((galleryItem) => ({
-                  file_id: galleryItem.file_id,
-                }))
-              )
-            ) {
-              delete data.gallery_items;
-            }
+          if (data.approved_at) {
+            next.name = "services-show";
+            next.query = { updated: true };
           }
-        );
-
-        // Return the response if only a preview.
-        if (preview) {
-          response.data.id = this.service.id;
-          return response;
+        } catch (err) {
+          console.log(err);
         }
-
-        const updateRequestId = response.id;
-        let next = {
-          name: 'services-updated',
-          params: { service: this.service.id },
-        };
-
-        if (this.auth.isGlobalAdmin) {
-          try {
-            const { data } = await http.get(
-              `/update-requests/${updateRequestId}`
-            );
-            if (data.approved_at) {
-              next.name = 'services-show';
-              next.query = { updated: true };
-            }
-          } catch (err) {
-            console.log(err);
-          }
-        }
-        this.$router.push(next);
-      },
-      async onPreview() {
-        this.updateRequest = await this.onSubmit(true);
-      },
-      onTabChange({ index }) {
-        this.tabs.forEach((tab) => (tab.active = false));
-        const tabId = this.allowedTabs[index].id;
-        this.tabs.find((tab) => tab.id === tabId).active = true;
-      },
-      onNext() {
-        const currentTabIndex = this.allowedTabs.findIndex(
-          (tab) => tab.active === true
-        );
-        this.tabs.forEach((tab) => (tab.active = false));
-        const newTabId = this.allowedTabs[currentTabIndex + 1].id;
-        this.tabs.find((tab) => tab.id === newTabId).active = true;
-        this.scrollToTop();
-      },
-      scrollToTop() {
-        document.getElementById('main-content').scrollIntoView();
-      },
-      isTabActive(id) {
-        const tab = this.allowedTabs.find((tab) => tab.id === id);
-
-        return tab === undefined ? false : tab.active;
-      },
+      }
+      this.$router.push(next);
     },
-    created() {
-      this.fetchService();
+    async onPreview() {
+      this.updateRequest = await this.onSubmit(true);
     },
-  };
+    onTabChange({ index }) {
+      this.tabs.forEach(tab => (tab.active = false));
+      const tabId = this.allowedTabs[index].id;
+      this.tabs.find(tab => tab.id === tabId).active = true;
+    },
+    onNext() {
+      const currentTabIndex = this.allowedTabs.findIndex(
+        tab => tab.active === true
+      );
+      this.tabs.forEach(tab => (tab.active = false));
+      const newTabId = this.allowedTabs[currentTabIndex + 1].id;
+      this.tabs.find(tab => tab.id === newTabId).active = true;
+      this.scrollToTop();
+    },
+    scrollToTop() {
+      document.getElementById("main-content").scrollIntoView();
+    },
+    isTabActive(id) {
+      const tab = this.allowedTabs.find(tab => tab.id === id);
+
+      return tab === undefined ? false : tab.active;
+    }
+  },
+  created() {
+    this.fetchService();
+  }
+};
 </script>

--- a/src/views/services/Show.vue
+++ b/src/views/services/Show.vue
@@ -17,6 +17,10 @@
                 <gov-caption size="m">{{ service.name }}</gov-caption>
                 View {{ service.type }}
               </gov-heading>
+              <gov-inset-text v-if="updated"
+                >{{ service.type }} {{ service.name }} has been
+                updated</gov-inset-text
+              >
             </gov-grid-column>
             <gov-grid-column
               v-if="auth.isServiceAdmin(service)"
@@ -55,63 +59,65 @@
 </template>
 
 <script>
-import http from "@/http";
+  import http from '@/http';
 
-export default {
-  name: "ShowService",
-  data() {
-    return {
-      loading: false,
-      service: null,
-      tabs: [
-        { heading: "Details", to: { name: "services-show" } },
-        {
-          heading: "Additional info",
-          to: { name: "services-show-additional-info" }
-        },
-        {
-          heading: "Good to know",
-          to: { name: "services-show-useful-info" }
-        },
-        {
-          heading: "Contact info",
-          to: { name: "services-show-contact-info" }
-        },
-        { heading: "Who is it for?", to: { name: "services-show-who-for" } },
-        { heading: "Locations", to: { name: "services-show-locations" } },
-        { heading: "Referral", to: { name: "services-show-referral" } }
-      ]
-    };
-  },
-  methods: {
-    async fetchService() {
-      this.loading = true;
-
-      // Fetch the services.
-      const servicesResponse = await http.get(
-        `/services/${this.$route.params.service}`,
-        { params: { include: "organisation" } }
-      );
-      this.service = servicesResponse.data.data;
-
-      // Fetch the service locations.
-      const serviceLocations = await this.fetchAll("/service-locations", {
-        "filter[service_id]": this.$route.params.service,
-        include: "location"
-      });
-      this.service.service_locations = serviceLocations;
-
-      this.loading = false;
+  export default {
+    name: 'ShowService',
+    data() {
+      return {
+        loading: false,
+        service: null,
+        updated: false,
+        tabs: [
+          { heading: 'Details', to: { name: 'services-show' } },
+          {
+            heading: 'Additional info',
+            to: { name: 'services-show-additional-info' },
+          },
+          {
+            heading: 'Good to know',
+            to: { name: 'services-show-useful-info' },
+          },
+          {
+            heading: 'Contact info',
+            to: { name: 'services-show-contact-info' },
+          },
+          { heading: 'Who is it for?', to: { name: 'services-show-who-for' } },
+          { heading: 'Locations', to: { name: 'services-show-locations' } },
+          { heading: 'Referral', to: { name: 'services-show-referral' } },
+        ],
+      };
     },
-    onEdit() {
-      alert("Edit");
+    methods: {
+      async fetchService() {
+        this.loading = true;
+
+        // Fetch the services.
+        const servicesResponse = await http.get(
+          `/services/${this.$route.params.service}`,
+          { params: { include: 'organisation' } }
+        );
+        this.service = servicesResponse.data.data;
+
+        // Fetch the service locations.
+        const serviceLocations = await this.fetchAll('/service-locations', {
+          'filter[service_id]': this.$route.params.service,
+          include: 'location',
+        });
+        this.service.service_locations = serviceLocations;
+
+        this.loading = false;
+      },
+      onEdit() {
+        alert('Edit');
+      },
+      onDelete() {
+        this.$router.push({ name: 'services-index' });
+      },
     },
-    onDelete() {
-      this.$router.push({ name: "services-index" });
-    }
-  },
-  created() {
-    this.fetchService();
-  }
-};
+    created() {
+      this.updated = this.$route.query.updated || false;
+      this.fetchService();
+    },
+  };
 </script>

--- a/src/views/services/Show.vue
+++ b/src/views/services/Show.vue
@@ -59,65 +59,65 @@
 </template>
 
 <script>
-  import http from '@/http';
+import http from "@/http";
 
-  export default {
-    name: 'ShowService',
-    data() {
-      return {
-        loading: false,
-        service: null,
-        updated: false,
-        tabs: [
-          { heading: 'Details', to: { name: 'services-show' } },
-          {
-            heading: 'Additional info',
-            to: { name: 'services-show-additional-info' },
-          },
-          {
-            heading: 'Good to know',
-            to: { name: 'services-show-useful-info' },
-          },
-          {
-            heading: 'Contact info',
-            to: { name: 'services-show-contact-info' },
-          },
-          { heading: 'Who is it for?', to: { name: 'services-show-who-for' } },
-          { heading: 'Locations', to: { name: 'services-show-locations' } },
-          { heading: 'Referral', to: { name: 'services-show-referral' } },
-        ],
-      };
+export default {
+  name: "ShowService",
+  data() {
+    return {
+      loading: false,
+      service: null,
+      updated: false,
+      tabs: [
+        { heading: "Details", to: { name: "services-show" } },
+        {
+          heading: "Additional info",
+          to: { name: "services-show-additional-info" }
+        },
+        {
+          heading: "Good to know",
+          to: { name: "services-show-useful-info" }
+        },
+        {
+          heading: "Contact info",
+          to: { name: "services-show-contact-info" }
+        },
+        { heading: "Who is it for?", to: { name: "services-show-who-for" } },
+        { heading: "Locations", to: { name: "services-show-locations" } },
+        { heading: "Referral", to: { name: "services-show-referral" } }
+      ]
+    };
+  },
+  methods: {
+    async fetchService() {
+      this.loading = true;
+
+      // Fetch the services.
+      const servicesResponse = await http.get(
+        `/services/${this.$route.params.service}`,
+        { params: { include: "organisation" } }
+      );
+      this.service = servicesResponse.data.data;
+
+      // Fetch the service locations.
+      const serviceLocations = await this.fetchAll("/service-locations", {
+        "filter[service_id]": this.$route.params.service,
+        include: "location"
+      });
+      this.service.service_locations = serviceLocations;
+
+      this.loading = false;
     },
-    methods: {
-      async fetchService() {
-        this.loading = true;
-
-        // Fetch the services.
-        const servicesResponse = await http.get(
-          `/services/${this.$route.params.service}`,
-          { params: { include: 'organisation' } }
-        );
-        this.service = servicesResponse.data.data;
-
-        // Fetch the service locations.
-        const serviceLocations = await this.fetchAll('/service-locations', {
-          'filter[service_id]': this.$route.params.service,
-          include: 'location',
-        });
-        this.service.service_locations = serviceLocations;
-
-        this.loading = false;
-      },
-      onEdit() {
-        alert('Edit');
-      },
-      onDelete() {
-        this.$router.push({ name: 'services-index' });
-      },
+    onEdit() {
+      alert("Edit");
     },
-    created() {
-      this.updated = this.$route.query.updated || false;
-      this.fetchService();
-    },
-  };
+    onDelete() {
+      this.$router.push({ name: "services-index" });
+    }
+  },
+  created() {
+    this.updated = this.$route.query.updated || false;
+    this.fetchService();
+  }
+};
 </script>


### PR DESCRIPTION
### Summary
https://app.clubhouse.io/ayup-digital-ltd/story/198/global-admins-to-skip-update-request-flow
Updates to Organisations, Services, Locations and Service-Locations will have a different outcome based on the role of the user. Non Global Admins will continue as is currently with a view explaining the update request, while Global Admins will be taken to the updated entities show view.

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
NA

### Notes
NA
