### PR TITLE
Feature/hounslow ch231 taxonomy search UI

### DIFF
--- a/src/components/Ck/CkTaxonomyInput.vue
+++ b/src/components/Ck/CkTaxonomyInput.vue
@@ -1,23 +1,22 @@
 <template>
   <ck-loader v-if="loading" />
+  <div v-else>
+    <gov-form-group>
+      <gov-label for="filter[name]">Taxonomy name</gov-label>
+      <gov-input
+        v-model="filters.name"
+        id="filter[name]"
+        name="filter[name]"
+        type="search"
+      />
+    </gov-form-group>
 
-  <!-- Level: 1 -->
-  <gov-form-group v-else>
-    <gov-checkboxes :invalid="error">
-      <gov-checkbox
-        v-for="taxonomy in taxonomies"
-        :key="taxonomy.id"
-        :value="value.includes(taxonomy.id)"
-        @input="onInput({ taxonomy, enabled: $event })"
-        :id="taxonomy.id"
-        :name="taxonomy.id"
-        :label="taxonomy.name"
-        :disabled="disabled"
-      >
-        <!-- Level: 2 -->
+    <!-- Level: 1 -->
+    <gov-form-group>
+      <gov-checkboxes :invalid="error">
         <gov-checkbox
-          class="govuk-checkboxes__item--nested"
-          v-for="taxonomy in taxonomy.children"
+          v-for="taxonomy in taxonomies"
+          v-if="filteredTaxonomyIds.includes(taxonomy.id)"
           :key="taxonomy.id"
           :value="value.includes(taxonomy.id)"
           @input="onInput({ taxonomy, enabled: $event })"
@@ -26,10 +25,11 @@
           :label="taxonomy.name"
           :disabled="disabled"
         >
-          <!-- Level: 3 -->
+          <!-- Level: 2 -->
           <gov-checkbox
             class="govuk-checkboxes__item--nested"
             v-for="taxonomy in taxonomy.children"
+            v-if="filteredTaxonomyIds.includes(taxonomy.id)"
             :key="taxonomy.id"
             :value="value.includes(taxonomy.id)"
             @input="onInput({ taxonomy, enabled: $event })"
@@ -38,10 +38,11 @@
             :label="taxonomy.name"
             :disabled="disabled"
           >
-            <!-- Level: 4 -->
+            <!-- Level: 3 -->
             <gov-checkbox
               class="govuk-checkboxes__item--nested"
               v-for="taxonomy in taxonomy.children"
+              v-if="filteredTaxonomyIds.includes(taxonomy.id)"
               :key="taxonomy.id"
               :value="value.includes(taxonomy.id)"
               @input="onInput({ taxonomy, enabled: $event })"
@@ -50,10 +51,11 @@
               :label="taxonomy.name"
               :disabled="disabled"
             >
-              <!-- Level: 5 -->
+              <!-- Level: 4 -->
               <gov-checkbox
                 class="govuk-checkboxes__item--nested"
                 v-for="taxonomy in taxonomy.children"
+                v-if="filteredTaxonomyIds.includes(taxonomy.id)"
                 :key="taxonomy.id"
                 :value="value.includes(taxonomy.id)"
                 @input="onInput({ taxonomy, enabled: $event })"
@@ -62,10 +64,11 @@
                 :label="taxonomy.name"
                 :disabled="disabled"
               >
-                <!-- Level: 6 -->
+                <!-- Level: 5 -->
                 <gov-checkbox
                   class="govuk-checkboxes__item--nested"
                   v-for="taxonomy in taxonomy.children"
+                  v-if="filteredTaxonomyIds.includes(taxonomy.id)"
                   :key="taxonomy.id"
                   :value="value.includes(taxonomy.id)"
                   @input="onInput({ taxonomy, enabled: $event })"
@@ -73,29 +76,47 @@
                   :name="taxonomy.id"
                   :label="taxonomy.name"
                   :disabled="disabled"
-                />
-                <!-- /Level: 6 -->
+                >
+                  <!-- Level: 6 -->
+                  <gov-checkbox
+                    class="govuk-checkboxes__item--nested"
+                    v-for="taxonomy in taxonomy.children"
+                    v-if="filteredTaxonomyIds.includes(taxonomy.id)"
+                    :key="taxonomy.id"
+                    :value="value.includes(taxonomy.id)"
+                    @input="onInput({ taxonomy, enabled: $event })"
+                    :id="taxonomy.id"
+                    :name="taxonomy.id"
+                    :label="taxonomy.name"
+                    :disabled="disabled"
+                  />
+                  <!-- /Level: 6 -->
+                </gov-checkbox>
+                <!-- /Level: 5 -->
               </gov-checkbox>
-              <!-- /Level: 5 -->
+              <!-- /Level: 4 -->
             </gov-checkbox>
-            <!-- /Level: 4 -->
+            <!-- /Level: 3 -->
           </gov-checkbox>
-          <!-- /Level: 3 -->
+          <!-- /Level: 2 -->
         </gov-checkbox>
-        <!-- /Level: 2 -->
-      </gov-checkbox>
-    </gov-checkboxes>
+      </gov-checkboxes>
 
-    <gov-error-message v-if="error" v-text="error" for="category_taxonomies" />
-  </gov-form-group>
-  <!-- /Level: 1 -->
+      <gov-error-message
+        v-if="error"
+        v-text="error"
+        for="category_taxonomies"
+      />
+    </gov-form-group>
+    <!-- /Level: 1 -->
+  </div>
 </template>
 
 <script>
 import http from "@/http";
 
 export default {
-  name: "CategoryTaxonomyInput",
+  name: "TaxonomyInput",
   props: {
     value: {
       required: true,
@@ -103,6 +124,13 @@ export default {
     },
     error: {
       required: true
+    },
+    root: {
+      required: true,
+      type: String,
+      validator: function(value) {
+        return ["categories", "organisations"].indexOf(value) !== -1;
+      }
     },
     disabled: {
       required: false,
@@ -120,13 +148,40 @@ export default {
       taxonomies: [],
       flattenedTaxonomies: [],
       loading: false,
-      enabledTaxonomies: []
+      enabledTaxonomies: [],
+      filters: {
+        name: ""
+      }
     };
+  },
+  computed: {
+    filteredTaxonomyIds() {
+      if (this.filters.name.length > 2) {
+        const filteredTaxonomyIds = this.flattenedTaxonomies.reduce(
+          (filteredTaxonomies, taxonomy) => {
+            if (
+              taxonomy.name
+                .toLowerCase()
+                .includes(this.filters.name.toLowerCase())
+            ) {
+              filteredTaxonomies = filteredTaxonomies.concat(
+                this.getTaxonomyAndAncestorsIds(taxonomy)
+              );
+            }
+            return filteredTaxonomies;
+          },
+          []
+        );
+        return [...new Set(filteredTaxonomyIds)];
+      } else {
+        return this.flattenedTaxonomies.map(taxonomy => taxonomy.id);
+      }
+    }
   },
   methods: {
     async fetchTaxonomies() {
       this.loading = true;
-      const { data } = await http.get("/taxonomies/categories");
+      const { data } = await http.get(`/taxonomies/${this.root}`);
       this.taxonomies = data.data;
       this.setFlattenedTaxonomies();
       this.loading = false;
@@ -182,6 +237,21 @@ export default {
           }
         }
       }
+    },
+    getTaxonomyAndAncestorsIds(taxonomy) {
+      let ids = [taxonomy.id];
+      if (taxonomy.parent_id) {
+        const parent = this.flattenedTaxonomies.find(
+          tax => tax.id === taxonomy.parent_id
+        );
+        ids = ids.concat(this.getTaxonomyAndAncestorsIds(parent));
+      }
+      return ids;
+    },
+    filteredTaxonomies(taxonomies) {
+      return taxonomies.filter(taxonomy =>
+        this.filteredTaxonomyIds.includes(taxonomy.id)
+      );
     }
   },
   created() {

--- a/src/components/Ck/CkTaxonomyInput.vue
+++ b/src/components/Ck/CkTaxonomyInput.vue
@@ -2,7 +2,7 @@
   <ck-loader v-if="loading" />
   <div v-else>
     <gov-form-group>
-      <gov-label for="filter[name]">Taxonomy name</gov-label>
+      <gov-label for="filter[name]">Search by taxonomy name</gov-label>
       <gov-input
         v-model="filters.name"
         id="filter[name]"
@@ -12,7 +12,7 @@
     </gov-form-group>
 
     <!-- Level: 1 -->
-    <gov-form-group>
+    <gov-form-group v-if="filteredTaxonomyIds.length">
       <gov-checkboxes :invalid="error">
         <gov-checkbox
           v-for="taxonomy in taxonomies"
@@ -109,6 +109,9 @@
       />
     </gov-form-group>
     <!-- /Level: 1 -->
+    <gov-inset-text v-else>
+      No matching taxonomies found
+    </gov-inset-text>
   </div>
 </template>
 

--- a/src/views/collections/categories/forms/CollectionForm.vue
+++ b/src/views/collections/categories/forms/CollectionForm.vue
@@ -60,7 +60,8 @@
     />
 
     <gov-label class="govuk-!-font-weight-bold">Taxonomies</gov-label>
-    <ck-category-taxonomy-input
+    <ck-taxonomy-input
+      root="categories"
       :invalid="errors.has('category_taxonomies')"
       :value="category_taxonomies"
       @input="$emit('update:category_taxonomies', $event)"
@@ -73,12 +74,12 @@
 
 <script>
 import icons from "@/storage/icons";
-import CkCategoryTaxonomyInput from "@/components/Ck/CkCategoryTaxonomyInput";
+import CkTaxonomyInput from "@/components/Ck/CkTaxonomyInput";
 import CkSideboxesInput from "@/views/collections/inputs/SideboxesInput";
 
 export default {
   name: "CollectionForm",
-  components: { CkCategoryTaxonomyInput, CkSideboxesInput },
+  components: { CkTaxonomyInput, CkSideboxesInput },
   props: {
     errors: {
       required: true,

--- a/src/views/collections/personas/forms/CollectionForm.vue
+++ b/src/views/collections/personas/forms/CollectionForm.vue
@@ -61,7 +61,8 @@
     />
 
     <gov-label class="govuk-!-font-weight-bold">Taxonomies</gov-label>
-    <ck-category-taxonomy-input
+    <ck-taxonomy-input
+      root="categories"
       :invalid="errors.has('category_taxonomies')"
       :value="category_taxonomies"
       @input="$emit('update:category_taxonomies', $event)"
@@ -74,12 +75,12 @@
 
 <script>
 import CkImageInput from "@/components/Ck/CkImageInput";
-import CkCategoryTaxonomyInput from "@/components/Ck/CkCategoryTaxonomyInput";
+import CkTaxonomyInput from "@/components/Ck/CkTaxonomyInput";
 import CkSideboxesInput from "@/views/collections/inputs/SideboxesInput";
 
 export default {
   name: "CollectionForm",
-  components: { CkImageInput, CkCategoryTaxonomyInput, CkSideboxesInput },
+  components: { CkImageInput, CkTaxonomyInput, CkSideboxesInput },
   props: {
     errors: {
       required: true,

--- a/src/views/organisations/Edit.vue
+++ b/src/views/organisations/Edit.vue
@@ -77,7 +77,8 @@
                 <gov-form-group
                   :invalid="form.$errors.has('category_taxonomies')"
                 >
-                  <ck-category-taxonomy-input
+                  <ck-taxonomy-input
+                    root="categories"
                     :value.sync="form.category_taxonomies"
                     @input="$emit('update:category_taxonomies', $event)"
                     :error="form.$errors.get('category_taxonomies')"
@@ -116,11 +117,11 @@ import http from "@/http";
 import Form from "@/classes/Form";
 import OrganisationTab from "./OrganisationTab";
 import OrganisationForm from "./forms/OrganisationForm";
-import CkCategoryTaxonomyInput from "@/components/Ck/CkCategoryTaxonomyInput";
+import CkTaxonomyInput from "@/components/Ck/CkTaxonomyInput";
 
 export default {
   name: "EditOrganisation",
-  components: { OrganisationForm, OrganisationTab, CkCategoryTaxonomyInput },
+  components: { OrganisationForm, OrganisationTab, CkTaxonomyInput },
   data() {
     return {
       loading: false,

--- a/src/views/services/forms/TaxonomiesTab.vue
+++ b/src/views/services/forms/TaxonomiesTab.vue
@@ -15,8 +15,9 @@
         <gov-section-break size="l" />
 
         <gov-form-group :invalid="errors.has('category_taxonomies')">
-          <ck-category-taxonomy-input
+          <ck-taxonomy-input
             :value="category_taxonomies"
+            root="categories"
             @input="$emit('update:category_taxonomies', $event)"
             :error="errors.get('category_taxonomies')"
             @clear="$emit('clear', 'category_taxonomies')"
@@ -35,11 +36,11 @@
   </div>
 </template>
 <script>
-import CkCategoryTaxonomyInput from "@/components/Ck/CkCategoryTaxonomyInput";
+import CkTaxonomyInput from "@/components/Ck/CkTaxonomyInput";
 
 export default {
   name: "TaxonomiesTab",
-  components: { CkCategoryTaxonomyInput },
+  components: { CkTaxonomyInput },
   props: {
     errors: {
       required: true


### PR DESCRIPTION
### Summary
https://app.clubhouse.io/ayup-digital-ltd/story/231/taxonomy-search-ui

Create a search filter for the taxonomy input component allowing users to filter taxonomies by name or name partial.

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
NA

### Notes
NA
