### PR TITLE
Feature/hounslow ch201 support homepage banners in cms

### DIFF
--- a/src/components/Ck/CkBannerInput.vue
+++ b/src/components/Ck/CkBannerInput.vue
@@ -1,0 +1,97 @@
+<template>
+  <div>
+    <ck-text-input
+      :value="banner.title || ''"
+      @input="onInput({ field: 'title', value: $event })"
+      label="What is the banner title?"
+      help="This text will appear as the large heading on the banner (70 characters max)"
+      :error="errors.title"
+      id="banner.title"
+    />
+
+    <ck-wysiwyg-input
+      :value="banner.content || ''"
+      @input="onInput({ field: 'content', value: $event })"
+      label="Banner description"
+      help="This text will appear as the smaller description text on the banner (200 characters max)"
+      :error="errors.content"
+      id="banner.content"
+    />
+
+    <ck-image-input
+      v-if="banner.has_image"
+      @input="onInput({ field: 'image_file_id', value: $event.file_id })"
+      id="logo"
+      label="Add a logo"
+      hint="Click 'Choose file' below to upload a logo to be displayed on the banner"
+      accept="image/x-png"
+      :existing-url="
+        banner.has_image
+          ? apiUrl(`/settings/banner-image.png?v=${now}`)
+          : undefined
+      "
+    />
+
+    <ck-text-input
+      :value="banner.button_text || ''"
+      @input="onInput({ field: 'button_text', value: $event })"
+      label="What should the button say?"
+      hint='eg. "Find out more" (30 characters max)'
+      :error="errors.button_text"
+      id="banner.button_text"
+    />
+
+    <ck-text-input
+      :value="banner.button_url || ''"
+      @input="onInput({ field: 'button_url', value: $event })"
+      label="What page should the banner link to?"
+      hint="Copy and paste the web address below"
+      :error="errors.button_url"
+      id="banner.button_url"
+      type="url"
+    />
+  </div>
+</template>
+
+<script>
+  import CkImageInput from './CkImageInput';
+
+  export default {
+    components: {
+      CkImageInput,
+    },
+
+    props: {
+      banner: {
+        type: Object,
+        default() {
+          return {
+            title: '',
+            content: '',
+            button_text: '',
+            button_url: '',
+          };
+        },
+      },
+      errors: {
+        type: Object,
+        default() {
+          return {};
+        },
+      },
+    },
+
+    methods: {
+      onInput({ field, value }) {
+        const banner = { ...this.banner };
+
+        banner[field] = value;
+
+        this.$emit('update', banner);
+        this.$emit('clear', `banner.${field}`);
+      },
+    },
+  };
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/components/Ck/CkBannerInput.vue
+++ b/src/components/Ck/CkBannerInput.vue
@@ -50,6 +50,7 @@
       id="banner.button_url"
       type="url"
     />
+    <slot />
   </gov-inset-text>
 </template>
 

--- a/src/components/Ck/CkBannerInput.vue
+++ b/src/components/Ck/CkBannerInput.vue
@@ -1,11 +1,11 @@
 <template>
-  <div>
+  <gov-inset-text>
     <ck-text-input
       :value="banner.title || ''"
       @input="onInput({ field: 'title', value: $event })"
       label="What is the banner title?"
       help="This text will appear as the large heading on the banner (70 characters max)"
-      :error="errors.title"
+      :error="errors ? errors.title : null"
       id="banner.title"
     />
 
@@ -14,12 +14,12 @@
       @input="onInput({ field: 'content', value: $event })"
       label="Banner description"
       help="This text will appear as the smaller description text on the banner (200 characters max)"
-      :error="errors.content"
+      :error="errors ? errors.content : null"
       id="banner.content"
     />
 
     <ck-image-input
-      v-if="banner.has_image"
+      v-if="showImageInput"
       @input="onInput({ field: 'image_file_id', value: $event.file_id })"
       id="logo"
       label="Add a logo"
@@ -37,7 +37,7 @@
       @input="onInput({ field: 'button_text', value: $event })"
       label="What should the button say?"
       hint='eg. "Find out more" (30 characters max)'
-      :error="errors.button_text"
+      :error="errors ? errors.button_text : null"
       id="banner.button_text"
     />
 
@@ -46,11 +46,11 @@
       @input="onInput({ field: 'button_url', value: $event })"
       label="What page should the banner link to?"
       hint="Copy and paste the web address below"
-      :error="errors.button_url"
+      :error="errors ? errors.button_url : null"
       id="banner.button_url"
       type="url"
     />
-  </div>
+  </gov-inset-text>
 </template>
 
 <script>
@@ -59,6 +59,11 @@
   export default {
     components: {
       CkImageInput,
+    },
+
+    model: {
+      prop: 'banner',
+      event: 'update',
     },
 
     props: {
@@ -78,6 +83,10 @@
         default() {
           return {};
         },
+      },
+      showImageInput: {
+        type: Boolean,
+        default: false,
       },
     },
 

--- a/src/components/Ck/CkBannerInput.vue
+++ b/src/components/Ck/CkBannerInput.vue
@@ -55,53 +55,53 @@
 </template>
 
 <script>
-  import CkImageInput from './CkImageInput';
+import CkImageInput from "./CkImageInput";
 
-  export default {
-    components: {
-      CkImageInput,
+export default {
+  components: {
+    CkImageInput
+  },
+
+  model: {
+    prop: "banner",
+    event: "update"
+  },
+
+  props: {
+    banner: {
+      type: Object,
+      default() {
+        return {
+          title: "",
+          content: "",
+          button_text: "",
+          button_url: ""
+        };
+      }
     },
-
-    model: {
-      prop: 'banner',
-      event: 'update',
+    errors: {
+      type: Object,
+      default() {
+        return {};
+      }
     },
+    showImageInput: {
+      type: Boolean,
+      default: false
+    }
+  },
 
-    props: {
-      banner: {
-        type: Object,
-        default() {
-          return {
-            title: '',
-            content: '',
-            button_text: '',
-            button_url: '',
-          };
-        },
-      },
-      errors: {
-        type: Object,
-        default() {
-          return {};
-        },
-      },
-      showImageInput: {
-        type: Boolean,
-        default: false,
-      },
-    },
+  methods: {
+    onInput({ field, value }) {
+      const banner = { ...this.banner };
 
-    methods: {
-      onInput({ field, value }) {
-        const banner = { ...this.banner };
+      banner[field] = value;
 
-        banner[field] = value;
-
-        this.$emit('update', banner);
-        this.$emit('clear', `banner.${field}`);
-      },
-    },
-  };
+      this.$emit("update", banner);
+      this.$emit("clear", `banner.${field}`);
+    }
+  }
+};
 </script>
 
 <style lang="scss" scoped></style>

--- a/src/components/Ck/CkImageInput.vue
+++ b/src/components/Ck/CkImageInput.vue
@@ -38,7 +38,7 @@
 
     <gov-error-message
       v-if="form.$errors.any()"
-      v-text="form.$errors.any(['is_private', 'mime_type', 'file'])"
+      v-text="form.$errors.get(['is_private', 'mime_type', 'file'])"
       :for="id"
     />
 
@@ -54,97 +54,98 @@
 </template>
 
 <script>
-import Form from "@/classes/Form";
+  import Form from '@/classes/Form';
 
-export default {
-  name: "CkImageInput",
-  props: {
-    label: {
-      required: true,
-      type: String
-    },
-    hint: {
-      required: false,
-      type: String
-    },
-    accept: {
-      required: false,
-      default: null
-    },
-    id: {
-      required: true,
-      type: String
-    },
-    existingUrl: {
-      required: false,
-      type: String
-    },
-    private: {
-      required: false,
-      type: Boolean,
-      default: false
-    }
-  },
-
-  data() {
-    return {
-      removeExisting: false,
-      form: new Form({
-        is_private: this.private,
-        mime_type: null,
-        file: null
-      })
-    };
-  },
-
-  methods: {
-    async onChange($event) {
-      // If null, then simply emit null.
-      if ($event === null) {
-        this.form.mime_type = null;
-        this.form.file = null;
-
-        this.$emit("input", { file_id: null, image: null });
-
-        return;
-      }
-
-      // Destructure the payload with the variables we need.
-      const { mime_type, content } = $event;
-
-      /*
-       * Reset remove existing flag to false since the user has interacted with
-       * the search input.
-       */
-      this.removeExisting = false;
-
-      // Set the variables in the form.
-      this.form.mime_type = mime_type;
-      this.form.file = content;
-
-      // Upload the file and retrieve the ID.
-      const {
-        data: { id }
-      } = await this.form.post("/files");
-
-      // Emit the file ID.
-      this.$emit("input", { file_id: id, image: this.form.file });
+  export default {
+    name: 'CkImageInput',
+    props: {
+      label: {
+        required: true,
+        type: String,
+      },
+      hint: {
+        required: false,
+        type: String,
+      },
+      accept: {
+        required: false,
+        default: null,
+      },
+      id: {
+        required: true,
+        type: String,
+      },
+      existingUrl: {
+        required: false,
+        type: String,
+      },
+      private: {
+        required: false,
+        type: Boolean,
+        default: false,
+      },
     },
 
-    onRemove() {
-      // For uploaded file.
-      if (this.form.file) {
-        this.$refs.file.$el.value = "";
-        this.form.mime_type = null;
-        this.form.file = null;
-        this.$emit("input", { file_id: null, image: null });
-        return;
-      }
+    data() {
+      return {
+        removeExisting: false,
+        form: new Form({
+          is_private: this.private,
+          mime_type: null,
+          file: null,
+        }),
+      };
+    },
 
-      // For existing file.
-      this.removeExisting = true;
-      this.$emit("input", { file_id: false, image: null });
-    }
-  }
-};
+    methods: {
+      async onChange($event) {
+        // If null, then simply emit null.
+        if ($event === null) {
+          this.form.mime_type = null;
+          this.form.file = null;
+
+          this.$emit('input', { file_id: null, image: null });
+
+          return;
+        }
+
+        // Destructure the payload with the variables we need.
+        const { mime_type, content } = $event;
+
+        /*
+         * Reset remove existing flag to false since the user has interacted with
+         * the search input.
+         */
+        this.removeExisting = false;
+
+        // Set the variables in the form.
+        this.form.mime_type = mime_type;
+        this.form.file = content;
+
+        // Upload the file and retrieve the ID.
+        const {
+          data: { id },
+        } = await this.form.post('/files');
+
+        // Emit the file ID.
+        this.$emit('input', { file_id: id, image: this.form.file });
+      },
+
+      onRemove() {
+        // For uploaded file.
+        if (this.form.file) {
+          this.$refs.file.$el.value = '';
+          this.form.mime_type = null;
+          this.form.file = null;
+          this.form.$errors.clear();
+          this.$emit('input', { file_id: null, image: null });
+          return;
+        }
+
+        // For existing file.
+        this.removeExisting = true;
+        this.$emit('input', { file_id: false, image: null });
+      },
+    },
+  };
 </script>

--- a/src/components/Ck/CkImageInput.vue
+++ b/src/components/Ck/CkImageInput.vue
@@ -54,98 +54,98 @@
 </template>
 
 <script>
-  import Form from '@/classes/Form';
+import Form from "@/classes/Form";
 
-  export default {
-    name: 'CkImageInput',
-    props: {
-      label: {
-        required: true,
-        type: String,
-      },
-      hint: {
-        required: false,
-        type: String,
-      },
-      accept: {
-        required: false,
-        default: null,
-      },
-      id: {
-        required: true,
-        type: String,
-      },
-      existingUrl: {
-        required: false,
-        type: String,
-      },
-      private: {
-        required: false,
-        type: Boolean,
-        default: false,
-      },
+export default {
+  name: "CkImageInput",
+  props: {
+    label: {
+      required: true,
+      type: String
+    },
+    hint: {
+      required: false,
+      type: String
+    },
+    accept: {
+      required: false,
+      default: null
+    },
+    id: {
+      required: true,
+      type: String
+    },
+    existingUrl: {
+      required: false,
+      type: String
+    },
+    private: {
+      required: false,
+      type: Boolean,
+      default: false
+    }
+  },
+
+  data() {
+    return {
+      removeExisting: false,
+      form: new Form({
+        is_private: this.private,
+        mime_type: null,
+        file: null
+      })
+    };
+  },
+
+  methods: {
+    async onChange($event) {
+      // If null, then simply emit null.
+      if ($event === null) {
+        this.form.mime_type = null;
+        this.form.file = null;
+
+        this.$emit("input", { file_id: null, image: null });
+
+        return;
+      }
+
+      // Destructure the payload with the variables we need.
+      const { mime_type, content } = $event;
+
+      /*
+       * Reset remove existing flag to false since the user has interacted with
+       * the search input.
+       */
+      this.removeExisting = false;
+
+      // Set the variables in the form.
+      this.form.mime_type = mime_type;
+      this.form.file = content;
+
+      // Upload the file and retrieve the ID.
+      const {
+        data: { id }
+      } = await this.form.post("/files");
+
+      // Emit the file ID.
+      this.$emit("input", { file_id: id, image: this.form.file });
     },
 
-    data() {
-      return {
-        removeExisting: false,
-        form: new Form({
-          is_private: this.private,
-          mime_type: null,
-          file: null,
-        }),
-      };
-    },
+    onRemove() {
+      // For uploaded file.
+      if (this.form.file) {
+        this.$refs.file.$el.value = "";
+        this.form.mime_type = null;
+        this.form.file = null;
+        this.form.$errors.clear();
+        this.$emit("input", { file_id: null, image: null });
+        return;
+      }
 
-    methods: {
-      async onChange($event) {
-        // If null, then simply emit null.
-        if ($event === null) {
-          this.form.mime_type = null;
-          this.form.file = null;
-
-          this.$emit('input', { file_id: null, image: null });
-
-          return;
-        }
-
-        // Destructure the payload with the variables we need.
-        const { mime_type, content } = $event;
-
-        /*
-         * Reset remove existing flag to false since the user has interacted with
-         * the search input.
-         */
-        this.removeExisting = false;
-
-        // Set the variables in the form.
-        this.form.mime_type = mime_type;
-        this.form.file = content;
-
-        // Upload the file and retrieve the ID.
-        const {
-          data: { id },
-        } = await this.form.post('/files');
-
-        // Emit the file ID.
-        this.$emit('input', { file_id: id, image: this.form.file });
-      },
-
-      onRemove() {
-        // For uploaded file.
-        if (this.form.file) {
-          this.$refs.file.$el.value = '';
-          this.form.mime_type = null;
-          this.form.file = null;
-          this.form.$errors.clear();
-          this.$emit('input', { file_id: null, image: null });
-          return;
-        }
-
-        // For existing file.
-        this.removeExisting = true;
-        this.$emit('input', { file_id: false, image: null });
-      },
-    },
-  };
+      // For existing file.
+      this.removeExisting = true;
+      this.$emit("input", { file_id: false, image: null });
+    }
+  }
+};
 </script>

--- a/src/views/admin/index/Cms.vue
+++ b/src/views/admin/index/Cms.vue
@@ -34,101 +34,111 @@
 </template>
 
 <script>
-import http from "@/http";
-import Form from "@/classes/Form";
+  import http from '@/http';
+  import Form from '@/classes/Form';
 
-export default {
-  name: "Cms",
+  export default {
+    name: 'Cms',
 
-  data() {
-    return {
-      tabs: [
-        {
-          heading: "Global",
-          to: { name: "admin-index-cms" }
-        },
-        {
-          heading: "Home",
-          to: { name: "admin-index-cms-frontend-home" }
-        },
-        {
-          heading: "Terms and Conditions",
-          to: { name: "admin-index-cms-frontend-terms-and-conditions" }
-        },
-        {
-          heading: "Privacy Policy",
-          to: { name: "admin-index-cms-frontend-privacy-policy" }
-        },
-        {
-          heading: "About",
-          to: { name: "admin-index-cms-frontend-about" }
-        },
-        {
-          heading: "Contact",
-          to: { name: "admin-index-cms-frontend-contact" }
-        },
-        {
-          heading: "Get Involved",
-          to: { name: "admin-index-cms-frontend-get-involved" }
-        },
-        {
-          heading: "Favourites",
-          to: { name: "admin-index-cms-frontend-favourites" }
-        },
-        {
-          heading: "Banner",
-          to: { name: "admin-index-cms-frontend-banner" }
-        }
-      ],
-      settings: null,
-      loading: false
-    };
-  },
-
-  created() {
-    this.fetchSettings();
-  },
-
-  methods: {
-    async fetchSettings() {
-      this.loading = true;
-
-      const {
-        data: { data: settings }
-      } = await http.get("/settings");
-
-      delete settings.cms.frontend.banner.has_image;
-      settings.cms.frontend.banner.enabled =
-        settings.cms.frontend.banner.title !== null;
-
-      this.settings = new Form(settings);
-
-      this.loading = false;
+    data() {
+      return {
+        tabs: [
+          {
+            heading: 'Global',
+            to: { name: 'admin-index-cms' },
+          },
+          {
+            heading: 'Home',
+            to: { name: 'admin-index-cms-frontend-home' },
+          },
+          {
+            heading: 'Terms and Conditions',
+            to: { name: 'admin-index-cms-frontend-terms-and-conditions' },
+          },
+          {
+            heading: 'Privacy Policy',
+            to: { name: 'admin-index-cms-frontend-privacy-policy' },
+          },
+          {
+            heading: 'About',
+            to: { name: 'admin-index-cms-frontend-about' },
+          },
+          {
+            heading: 'Contact',
+            to: { name: 'admin-index-cms-frontend-contact' },
+          },
+          {
+            heading: 'Get Involved',
+            to: { name: 'admin-index-cms-frontend-get-involved' },
+          },
+          {
+            heading: 'Favourites',
+            to: { name: 'admin-index-cms-frontend-favourites' },
+          },
+          {
+            heading: 'Banner',
+            to: { name: 'admin-index-cms-frontend-banner' },
+          },
+        ],
+        settings: null,
+        loading: false,
+      };
     },
 
-    async onSubmit() {
-      await this.settings.put("/settings", (config, data) => {
-        // Set banner values if disabled.
-        if (data.cms.frontend.banner.enabled === false) {
-          data.cms.frontend.banner.title = null;
-          data.cms.frontend.banner.content = null;
-          data.cms.frontend.banner.button_text = null;
-          data.cms.frontend.banner.button_url = null;
-          data.cms.frontend.banner.image_file_id = null;
-        }
+    created() {
+      this.fetchSettings();
+    },
 
-        // Remove the image from the request if null, or delete if false.
-        if (data.cms.frontend.banner.image_file_id === null) {
-          delete data.cms.frontend.banner.image_file_id;
-        } else if (data.cms.frontend.banner.image_file_id === false) {
-          data.cms.frontend.banner.image_file_id = null;
-        }
+    methods: {
+      async fetchSettings() {
+        this.loading = true;
 
-        // Remove banner enabled field.
-        delete data.cms.frontend.banner.enabled;
-      });
-      this.$router.push({ name: "admin-index-cms-updated" });
-    }
-  }
-};
+        const {
+          data: { data: settings },
+        } = await http.get('/settings');
+
+        settings.cms.frontend.banner.enabled =
+          settings.cms.frontend.banner.title !== null;
+
+        this.settings = new Form(settings);
+
+        this.loading = false;
+      },
+
+      async onSubmit() {
+        await this.settings.put('/settings', (config, data) => {
+          // Set banner values if disabled.
+          if (data.cms.frontend.banner.enabled === false) {
+            data.cms.frontend.banner.title = null;
+            data.cms.frontend.banner.content = null;
+            data.cms.frontend.banner.button_text = null;
+            data.cms.frontend.banner.button_url = null;
+            data.cms.frontend.banner.image_file_id = null;
+          }
+
+          // Remove the image from the request if null, or delete if false.
+          if (data.cms.frontend.banner.image_file_id === null) {
+            delete data.cms.frontend.banner.image_file_id;
+          } else if (data.cms.frontend.banner.image_file_id === false) {
+            data.cms.frontend.banner.image_file_id = null;
+          }
+
+          // Remove banner enabled field.
+          delete data.cms.frontend.banner.enabled;
+
+          data.cms.frontend.home.banners = data.cms.frontend.home.banners.filter(
+            (banner) => {
+              return !(
+                (banner.title == '') &
+                (banner.content == '') &
+                (banner.button_text == '') &
+                (banner.button_url == '')
+              );
+            }
+          );
+        });
+        this.$router.push({ name: 'admin-index-cms-updated' });
+      },
+    },
+  };
 </script>

--- a/src/views/admin/index/Cms.vue
+++ b/src/views/admin/index/Cms.vue
@@ -34,111 +34,111 @@
 </template>
 
 <script>
-  import http from '@/http';
-  import Form from '@/classes/Form';
+import http from "@/http";
+import Form from "@/classes/Form";
 
-  export default {
-    name: 'Cms',
+export default {
+  name: "Cms",
 
-    data() {
-      return {
-        tabs: [
-          {
-            heading: 'Global',
-            to: { name: 'admin-index-cms' },
-          },
-          {
-            heading: 'Home',
-            to: { name: 'admin-index-cms-frontend-home' },
-          },
-          {
-            heading: 'Terms and Conditions',
-            to: { name: 'admin-index-cms-frontend-terms-and-conditions' },
-          },
-          {
-            heading: 'Privacy Policy',
-            to: { name: 'admin-index-cms-frontend-privacy-policy' },
-          },
-          {
-            heading: 'About',
-            to: { name: 'admin-index-cms-frontend-about' },
-          },
-          {
-            heading: 'Contact',
-            to: { name: 'admin-index-cms-frontend-contact' },
-          },
-          {
-            heading: 'Get Involved',
-            to: { name: 'admin-index-cms-frontend-get-involved' },
-          },
-          {
-            heading: 'Favourites',
-            to: { name: 'admin-index-cms-frontend-favourites' },
-          },
-          {
-            heading: 'Banner',
-            to: { name: 'admin-index-cms-frontend-banner' },
-          },
-        ],
-        settings: null,
-        loading: false,
-      };
+  data() {
+    return {
+      tabs: [
+        {
+          heading: "Global",
+          to: { name: "admin-index-cms" }
+        },
+        {
+          heading: "Home",
+          to: { name: "admin-index-cms-frontend-home" }
+        },
+        {
+          heading: "Terms and Conditions",
+          to: { name: "admin-index-cms-frontend-terms-and-conditions" }
+        },
+        {
+          heading: "Privacy Policy",
+          to: { name: "admin-index-cms-frontend-privacy-policy" }
+        },
+        {
+          heading: "About",
+          to: { name: "admin-index-cms-frontend-about" }
+        },
+        {
+          heading: "Contact",
+          to: { name: "admin-index-cms-frontend-contact" }
+        },
+        {
+          heading: "Get Involved",
+          to: { name: "admin-index-cms-frontend-get-involved" }
+        },
+        {
+          heading: "Favourites",
+          to: { name: "admin-index-cms-frontend-favourites" }
+        },
+        {
+          heading: "Banner",
+          to: { name: "admin-index-cms-frontend-banner" }
+        }
+      ],
+      settings: null,
+      loading: false
+    };
+  },
+
+  created() {
+    this.fetchSettings();
+  },
+
+  methods: {
+    async fetchSettings() {
+      this.loading = true;
+
+      const {
+        data: { data: settings }
+      } = await http.get("/settings");
+
+      settings.cms.frontend.banner.enabled =
+        settings.cms.frontend.banner.title !== null;
+
+      this.settings = new Form(settings);
+
+      this.loading = false;
     },
 
-    created() {
-      this.fetchSettings();
-    },
+    async onSubmit() {
+      await this.settings.put("/settings", (config, data) => {
+        // Set banner values if disabled.
+        if (data.cms.frontend.banner.enabled === false) {
+          data.cms.frontend.banner.title = null;
+          data.cms.frontend.banner.content = null;
+          data.cms.frontend.banner.button_text = null;
+          data.cms.frontend.banner.button_url = null;
+          data.cms.frontend.banner.image_file_id = null;
+        }
 
-    methods: {
-      async fetchSettings() {
-        this.loading = true;
+        // Remove the image from the request if null, or delete if false.
+        if (data.cms.frontend.banner.image_file_id === null) {
+          delete data.cms.frontend.banner.image_file_id;
+        } else if (data.cms.frontend.banner.image_file_id === false) {
+          data.cms.frontend.banner.image_file_id = null;
+        }
 
-        const {
-          data: { data: settings },
-        } = await http.get('/settings');
+        // Remove banner enabled field.
+        delete data.cms.frontend.banner.enabled;
 
-        settings.cms.frontend.banner.enabled =
-          settings.cms.frontend.banner.title !== null;
-
-        this.settings = new Form(settings);
-
-        this.loading = false;
-      },
-
-      async onSubmit() {
-        await this.settings.put('/settings', (config, data) => {
-          // Set banner values if disabled.
-          if (data.cms.frontend.banner.enabled === false) {
-            data.cms.frontend.banner.title = null;
-            data.cms.frontend.banner.content = null;
-            data.cms.frontend.banner.button_text = null;
-            data.cms.frontend.banner.button_url = null;
-            data.cms.frontend.banner.image_file_id = null;
+        data.cms.frontend.home.banners = data.cms.frontend.home.banners.filter(
+          banner => {
+            return !(
+              (banner.title == "") &
+              (banner.content == "") &
+              (banner.button_text == "") &
+              (banner.button_url == "")
+            );
           }
-
-          // Remove the image from the request if null, or delete if false.
-          if (data.cms.frontend.banner.image_file_id === null) {
-            delete data.cms.frontend.banner.image_file_id;
-          } else if (data.cms.frontend.banner.image_file_id === false) {
-            data.cms.frontend.banner.image_file_id = null;
-          }
-
-          // Remove banner enabled field.
-          delete data.cms.frontend.banner.enabled;
-
-          data.cms.frontend.home.banners = data.cms.frontend.home.banners.filter(
-            (banner) => {
-              return !(
-                (banner.title == '') &
-                (banner.content == '') &
-                (banner.button_text == '') &
-                (banner.button_url == '')
-              );
-            }
-          );
-        });
-        this.$router.push({ name: 'admin-index-cms-updated' });
-      },
-    },
-  };
+        );
+      });
+      this.$router.push({ name: "admin-index-cms-updated" });
+    }
+  }
+};
 </script>

--- a/src/views/admin/index/cms/frontend/Banner.vue
+++ b/src/views/admin/index/cms/frontend/Banner.vue
@@ -7,108 +7,64 @@
 
       <ck-radio-input
         :value="frontend.banner.enabled"
-        @input="onInput({ field: 'enabled', value: $event })"
+        @input="frontend.banner.enabled = $event"
         id="cms.frontend.banner.enabled"
         label="Enable/Disable Banner"
         hint="Banner configuration will be shown when enabled"
         :options="[
           { value: false, label: 'Disabled' },
-          { value: true, label: 'Enabled' }
+          { value: true, label: 'Enabled' },
         ]"
         :error="null"
       />
 
-      <gov-inset-text v-show="frontend.banner.enabled">
-        <ck-text-input
-          :value="frontend.banner.title || ''"
-          @input="onInput({ field: 'title', value: $event })"
-          label="What is the banner title?"
-          help="This text will appear as the large heading on the banner (70 characters max)"
-          :error="errors.get('cms.frontend.banner.title')"
-          id="cms.frontend.banner.title"
+      <div v-show="frontend.banner.enabled">
+        <ck-banner-input
+          v-model="frontend.banner"
+          :errors="errors.get('cms.frontend.banner')"
+          :showImageInput="true"
         />
-
-        <ck-wysiwyg-input
-          :value="frontend.banner.content || ''"
-          @input="onInput({ field: 'content', value: $event })"
-          label="Banner description"
-          help="This text will appear as the smaller description text on the banner (200 characters max)"
-          :error="errors.get('cms.frontend.banner.content')"
-          id="cms.frontend.banner.content"
-        />
-
-        <ck-image-input
-          @input="onInput({ field: 'image_file_id', value: $event.file_id })"
-          id="logo"
-          label="Add a logo"
-          hint="Click 'Choose file' below to upload a logo to be displayed on the banner"
-          accept="image/x-png"
-          :existing-url="
-            frontend.banner.has_image
-              ? apiUrl(`/settings/banner-image.png?v=${now}`)
-              : undefined
-          "
-        />
-
-        <ck-text-input
-          :value="frontend.banner.button_text || ''"
-          @input="onInput({ field: 'button_text', value: $event })"
-          label="What should the button say?"
-          hint='eg. "Find out more" (30 characters max)'
-          :error="errors.get('cms.frontend.banner.button_text')"
-          id="cms.frontend.banner.button_text"
-        />
-
-        <ck-text-input
-          :value="frontend.banner.button_url || ''"
-          @input="onInput({ field: 'button_url', value: $event })"
-          label="What page should the banner link to?"
-          hint="Copy and paste the web address below"
-          :error="errors.get('cms.frontend.banner.button_url')"
-          id="cms.frontend.banner.button_url"
-          type="url"
-        />
-      </gov-inset-text>
+      </div>
     </gov-grid-column>
   </gov-grid-row>
 </template>
 
 <script>
-import CkImageInput from "@/components/Ck/CkImageInput";
+  import CkBannerInput from '@/components/Ck/CkBannerInput';
 
-export default {
-  name: "CmsFrontendBanner",
+  export default {
+    name: 'CmsFrontendBanner',
 
-  components: {
-    CkImageInput
-  },
-
-  model: {
-    prop: "frontend",
-    event: "input"
-  },
-
-  props: {
-    frontend: {
-      type: Object,
-      required: true
+    components: {
+      CkBannerInput,
     },
 
-    errors: {
-      type: Object,
-      required: true
-    }
-  },
+    model: {
+      prop: 'frontend',
+      event: 'input',
+    },
 
-  methods: {
-    onInput({ field, value }) {
-      const frontend = { ...this.frontend };
+    props: {
+      frontend: {
+        type: Object,
+        required: true,
+      },
 
-      frontend.banner[field] = value;
+      errors: {
+        type: Object,
+        required: true,
+      },
+    },
 
-      this.$emit("input", frontend);
-      this.$emit("clear", `frontend.banner.${field}`);
-    }
-  }
-};
+    methods: {
+      onInput({ field, value }) {
+        const frontend = { ...this.frontend };
+
+        frontend.banner[field] = value;
+
+        this.$emit('input', frontend);
+        this.$emit('clear', `frontend.banner.${field}`);
+      },
+    },
+  };
 </script>

--- a/src/views/admin/index/cms/frontend/Banner.vue
+++ b/src/views/admin/index/cms/frontend/Banner.vue
@@ -13,7 +13,7 @@
         hint="Banner configuration will be shown when enabled"
         :options="[
           { value: false, label: 'Disabled' },
-          { value: true, label: 'Enabled' },
+          { value: true, label: 'Enabled' }
         ]"
         :error="null"
       />
@@ -30,41 +30,41 @@
 </template>
 
 <script>
-  import CkBannerInput from '@/components/Ck/CkBannerInput';
+import CkBannerInput from "@/components/Ck/CkBannerInput";
 
-  export default {
-    name: 'CmsFrontendBanner',
+export default {
+  name: "CmsFrontendBanner",
 
-    components: {
-      CkBannerInput,
+  components: {
+    CkBannerInput
+  },
+
+  model: {
+    prop: "frontend",
+    event: "input"
+  },
+
+  props: {
+    frontend: {
+      type: Object,
+      required: true
     },
 
-    model: {
-      prop: 'frontend',
-      event: 'input',
-    },
+    errors: {
+      type: Object,
+      required: true
+    }
+  },
 
-    props: {
-      frontend: {
-        type: Object,
-        required: true,
-      },
+  methods: {
+    onInput({ field, value }) {
+      const frontend = { ...this.frontend };
 
-      errors: {
-        type: Object,
-        required: true,
-      },
-    },
+      frontend.banner[field] = value;
 
-    methods: {
-      onInput({ field, value }) {
-        const frontend = { ...this.frontend };
-
-        frontend.banner[field] = value;
-
-        this.$emit('input', frontend);
-        this.$emit('clear', `frontend.banner.${field}`);
-      },
-    },
-  };
+      this.$emit("input", frontend);
+      this.$emit("clear", `frontend.banner.${field}`);
+    }
+  }
+};
 </script>

--- a/src/views/admin/index/cms/frontend/Home.vue
+++ b/src/views/admin/index/cms/frontend/Home.vue
@@ -41,7 +41,11 @@
         :key="`home-banner-${index}`"
         v-model="frontend.home.banners[index]"
         :errors="errors.get('cms.frontend.home.banners')"
-      />
+      >
+        <gov-button @click="onRemoveBanner(index)" type="button" error
+          >Remove banner</gov-button
+        >
+      </ck-banner-input>
       <gov-button @click="onAddBanner">
         <template v-if="frontend.home.banners.length === 0"
           >Add Home Banner</template
@@ -89,6 +93,9 @@
           button_url: '',
         });
         this.frontend.home.banners = banners;
+      },
+      onRemoveBanner(index) {
+        this.frontend.home.banners.splice(index, 1);
       },
       onInput({ field, value }) {
         const frontend = { ...this.frontend };

--- a/src/views/admin/index/cms/frontend/Home.vue
+++ b/src/views/admin/index/cms/frontend/Home.vue
@@ -57,54 +57,54 @@
 </template>
 
 <script>
-  import CkBannerInput from '@/components/Ck/CkBannerInput';
+import CkBannerInput from "@/components/Ck/CkBannerInput";
 
-  export default {
-    name: 'CmsFrontendHome',
+export default {
+  name: "CmsFrontendHome",
 
-    components: {
-      CkBannerInput,
+  components: {
+    CkBannerInput
+  },
+
+  model: {
+    prop: "frontend",
+    event: "input"
+  },
+
+  props: {
+    frontend: {
+      type: Object,
+      required: true
     },
 
-    model: {
-      prop: 'frontend',
-      event: 'input',
+    errors: {
+      type: Object,
+      required: true
+    }
+  },
+
+  methods: {
+    onAddBanner() {
+      let banners = this.frontend.home.banners.slice();
+      banners.push({
+        title: "",
+        content: "",
+        button_text: "",
+        button_url: ""
+      });
+      this.frontend.home.banners = banners;
     },
-
-    props: {
-      frontend: {
-        type: Object,
-        required: true,
-      },
-
-      errors: {
-        type: Object,
-        required: true,
-      },
+    onRemoveBanner(index) {
+      this.frontend.home.banners.splice(index, 1);
     },
+    onInput({ field, value }) {
+      const frontend = { ...this.frontend };
 
-    methods: {
-      onAddBanner() {
-        let banners = this.frontend.home.banners.slice();
-        banners.push({
-          title: '',
-          content: '',
-          button_text: '',
-          button_url: '',
-        });
-        this.frontend.home.banners = banners;
-      },
-      onRemoveBanner(index) {
-        this.frontend.home.banners.splice(index, 1);
-      },
-      onInput({ field, value }) {
-        const frontend = { ...this.frontend };
+      frontend.home[field] = value;
 
-        frontend.home[field] = value;
-
-        this.$emit('input', frontend);
-        this.$emit('clear', `frontend.home.${field}`);
-      },
-    },
-  };
+      this.$emit("input", frontend);
+      this.$emit("clear", `frontend.home.${field}`);
+    }
+  }
+};
 </script>

--- a/src/views/admin/index/cms/frontend/Home.vue
+++ b/src/views/admin/index/cms/frontend/Home.vue
@@ -36,40 +36,68 @@
         :error="errors.get('cms.frontend.home.personas_content')"
         id="cms.frontend.home.personas_content"
       />
+      <ck-banner-input
+        v-for="(banner, index) in frontend.home.banners"
+        :key="`home-banner-${index}`"
+        v-model="frontend.home.banners[index]"
+        :errors="errors.get('cms.frontend.home.banners')"
+      />
+      <gov-button @click="onAddBanner">
+        <template v-if="frontend.home.banners.length === 0"
+          >Add Home Banner</template
+        >
+        <template v-else>Add another</template>
+      </gov-button>
     </gov-grid-column>
   </gov-grid-row>
 </template>
 
 <script>
-export default {
-  name: "CmsFrontendHome",
+  import CkBannerInput from '@/components/Ck/CkBannerInput';
 
-  model: {
-    prop: "frontend",
-    event: "input"
-  },
+  export default {
+    name: 'CmsFrontendHome',
 
-  props: {
-    frontend: {
-      type: Object,
-      required: true
+    components: {
+      CkBannerInput,
     },
 
-    errors: {
-      type: Object,
-      required: true
-    }
-  },
+    model: {
+      prop: 'frontend',
+      event: 'input',
+    },
 
-  methods: {
-    onInput({ field, value }) {
-      const frontend = { ...this.frontend };
+    props: {
+      frontend: {
+        type: Object,
+        required: true,
+      },
 
-      frontend.home[field] = value;
+      errors: {
+        type: Object,
+        required: true,
+      },
+    },
 
-      this.$emit("input", frontend);
-      this.$emit("clear", `frontend.home.${field}`);
-    }
-  }
-};
+    methods: {
+      onAddBanner() {
+        let banners = this.frontend.home.banners.slice();
+        banners.push({
+          title: '',
+          content: '',
+          button_text: '',
+          button_url: '',
+        });
+        this.frontend.home.banners = banners;
+      },
+      onInput({ field, value }) {
+        const frontend = { ...this.frontend };
+
+        frontend.home[field] = value;
+
+        this.$emit('input', frontend);
+        this.$emit('clear', `frontend.home.${field}`);
+      },
+    },
+  };
 </script>


### PR DESCRIPTION
### Summary
https://app.clubhouse.io/ayup-digital-ltd/story/201/support-homepage-banners-in-cms

UI to manage CMS banners for the Home tab. Created banner input component to share functionality with Banner tab.

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
NA

### Notes
NA
