### PR TITLE
Added admin UI for enabled status of collections

### DIFF
--- a/src/views/admin/index/collections/Categories.vue
+++ b/src/views/admin/index/collections/Categories.vue
@@ -33,27 +33,15 @@
       <gov-grid-column width="two-thirds">
         <ck-loader v-if="loading" />
         <gov-list v-else bullet>
-          <li v-for="collection in collections" :key="collection.id">
-            {{ collection.name }}&nbsp;
-            <gov-link
-              v-if="auth.isGlobalAdmin"
-              :to="{
-                name: 'collections-categories-edit',
-                params: { collection: collection.id }
-              }"
-            >
-              Edit
-            </gov-link>
-            <br />
-            <gov-link @click="onMoveUp(collection)" v-if="collection.order > 1"
-              >(Move up)</gov-link
-            >
-            <gov-link
-              @click="onMoveDown(collection)"
-              v-if="collection.order < collections.length"
-              >(Move down)</gov-link
-            >
-          </li>
+          <collection-list-item
+            v-for="collection in collections"
+            :key="collection.id"
+            :collection="collection"
+            :collections="collections"
+            type="category"
+            @move-up="onMoveUp"
+            @move-down="onMoveDown"
+          />
         </gov-list>
       </gov-grid-column>
     </gov-grid-row>
@@ -62,9 +50,13 @@
 
 <script>
 import http from "@/http";
+import CollectionListItem from "./CollectionListItem";
 
 export default {
   name: "ListCollectionCategories",
+
+  components: { CollectionListItem },
+
   data() {
     return {
       loading: false,
@@ -103,6 +95,7 @@ export default {
         intro: collection.intro,
         icon: collection.icon,
         order: collection.order,
+        enabled: collection.enabled,
         sideboxes: collection.sideboxes,
         category_taxonomies: collection.category_taxonomies.map(
           taxonomy => taxonomy.id

--- a/src/views/admin/index/collections/CollectionListItem.vue
+++ b/src/views/admin/index/collections/CollectionListItem.vue
@@ -1,0 +1,58 @@
+<template>
+  <li>
+    {{ collection.name }}&nbsp;<span
+      v-if="auth.isSuperAdmin && !collection.enabled"
+      >(disabled)</span
+    >&nbsp;
+    <gov-link
+      v-if="auth.isGlobalAdmin"
+      :to="{
+        name: editCollectionRoute,
+        params: { collection: collection.id }
+      }"
+    >
+      Edit
+    </gov-link>
+    <br />
+    <gov-link @click="$emit('move-up', collection)" v-if="collection.order > 1"
+      >(Move up)</gov-link
+    >
+    <gov-link
+      @click="$emit('move-down', collection)"
+      v-if="collection.order < collections.length"
+      >(Move down)</gov-link
+    >
+  </li>
+</template>
+
+<script>
+export default {
+  props: {
+    collections: {
+      type: Array,
+      required: true
+    },
+    collection: {
+      type: Object,
+      required: true
+    },
+    type: {
+      type: String,
+      required: true,
+      validator: function(value) {
+        return ["category", "persona"].indexOf(value) !== -1;
+      }
+    }
+  },
+
+  computed: {
+    editCollectionRoute() {
+      return this.type === "category"
+        ? "collections-categories-edit"
+        : "collections-personas-edit";
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/views/admin/index/collections/Personas.vue
+++ b/src/views/admin/index/collections/Personas.vue
@@ -31,27 +31,15 @@
       <gov-grid-column width="two-thirds">
         <ck-loader v-if="loading" />
         <gov-list v-else bullet>
-          <li v-for="collection in collections" :key="collection.id">
-            {{ collection.name }}&nbsp;
-            <gov-link
-              v-if="auth.isGlobalAdmin"
-              :to="{
-                name: 'collections-personas-edit',
-                params: { collection: collection.id }
-              }"
-            >
-              Edit
-            </gov-link>
-            <br />
-            <gov-link @click="onMoveUp(collection)" v-if="collection.order > 1"
-              >(Move up)</gov-link
-            >
-            <gov-link
-              @click="onMoveDown(collection)"
-              v-if="collection.order < collections.length"
-              >(Move down)</gov-link
-            >
-          </li>
+          <collection-list-item
+            v-for="collection in collections"
+            :key="collection.id"
+            :collection="collection"
+            :collections="collections"
+            type="persona"
+            @move-up="onMoveUp"
+            @move-down="onMoveDown"
+          />
         </gov-list>
       </gov-grid-column>
     </gov-grid-row>
@@ -60,9 +48,13 @@
 
 <script>
 import http from "@/http";
+import CollectionListItem from "./CollectionListItem";
 
 export default {
   name: "ListCollectionPersonas",
+
+  components: { CollectionListItem },
+
   data() {
     return {
       loading: false,
@@ -101,6 +93,7 @@ export default {
         intro: collection.intro,
         subtitle: collection.subtitle,
         order: collection.order,
+        enabled: collection.enabled,
         sideboxes: collection.sideboxes,
         category_taxonomies: collection.category_taxonomies.map(
           taxonomy => taxonomy.id

--- a/src/views/collections/categories/Create.vue
+++ b/src/views/collections/categories/Create.vue
@@ -25,6 +25,7 @@
             :intro.sync="form.intro"
             :icon.sync="form.icon"
             :order.sync="form.order"
+            :enabled.sync="form.enabled"
             :sideboxes.sync="form.sideboxes"
             :category_taxonomies.sync="form.category_taxonomies"
             @clear="form.$errors.clear($event)"
@@ -55,6 +56,7 @@ export default {
         intro: "",
         icon: "",
         order: 1,
+        enabled: true,
         sideboxes: [],
         category_taxonomies: []
       })

--- a/src/views/collections/categories/Edit.vue
+++ b/src/views/collections/categories/Edit.vue
@@ -31,6 +31,7 @@
               :intro.sync="form.intro"
               :icon.sync="form.icon"
               :order.sync="form.order"
+              :enabled.sync="form.enabled"
               :sideboxes.sync="form.sideboxes"
               :category_taxonomies.sync="form.category_taxonomies"
               @clear="form.$errors.clear($event)"
@@ -86,6 +87,7 @@ export default {
         intro: this.collection.intro,
         icon: this.collection.icon,
         order: this.collection.order,
+        enabled: this.collection.enabled,
         sideboxes: this.collection.sideboxes,
         category_taxonomies: this.collection.category_taxonomies.map(
           taxonomy => taxonomy.id

--- a/src/views/collections/categories/forms/CollectionForm.vue
+++ b/src/views/collections/categories/forms/CollectionForm.vue
@@ -46,6 +46,15 @@
       />
     </ck-select-input>
 
+    <collection-enabled-input
+      :value="enabled"
+      @input="onInput('enabled', $event)"
+      id="status"
+      type="category"
+      label="Status of Category"
+      :error="errors.get('enabled')"
+    />
+
     <gov-heading size="m">Sideboxes</gov-heading>
 
     <gov-body>
@@ -76,10 +85,11 @@
 import icons from "@/storage/icons";
 import CkTaxonomyInput from "@/components/Ck/CkTaxonomyInput";
 import CkSideboxesInput from "@/views/collections/inputs/SideboxesInput";
+import CollectionEnabledInput from "@/views/collections/inputs/CollectionEnabledInput";
 
 export default {
   name: "CollectionForm",
-  components: { CkTaxonomyInput, CkSideboxesInput },
+  components: { CollectionEnabledInput, CkTaxonomyInput, CkSideboxesInput },
   props: {
     errors: {
       required: true,
@@ -95,6 +105,9 @@ export default {
       required: true
     },
     order: {
+      required: true
+    },
+    enabled: {
       required: true
     },
     sideboxes: {

--- a/src/views/collections/inputs/CollectionEnabledInput.vue
+++ b/src/views/collections/inputs/CollectionEnabledInput.vue
@@ -1,0 +1,62 @@
+<template>
+  <gov-form-group :invalid="error !== null">
+    <gov-label :for="id" class="govuk-!-font-weight-bold">
+      <slot name="label">{{ label }}</slot>
+    </gov-label>
+    <slot name="hint">
+      <gov-hint v-if="hint" :for="id" v-text="hint" />
+    </slot>
+    <gov-radios>
+      <gov-radio
+        :bind-to="value"
+        @input="$emit('input', $event)"
+        :id="`${id}_enabled`"
+        :name="id"
+        label="Enabled"
+        :value="true"
+      />
+      <gov-radio
+        :bind-to="value"
+        @input="$emit('input', $event)"
+        :id="`${id}_disabled`"
+        :name="id"
+        label="Disabled"
+        :value="false"
+      />
+    </gov-radios>
+  </gov-form-group>
+</template>
+
+<script>
+export default {
+  props: {
+    value: {
+      required: true
+    },
+    error: {
+      required: true
+    },
+    id: {
+      type: String,
+      required: true
+    },
+    type: {
+      type: String,
+      required: true,
+      validator: function(value) {
+        return ["category", "persona"].indexOf(value) !== -1;
+      }
+    },
+    label: {
+      required: true,
+      type: String
+    },
+    hint: {
+      required: false,
+      type: String
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/views/collections/personas/Create.vue
+++ b/src/views/collections/personas/Create.vue
@@ -25,6 +25,7 @@
             :subtitle.sync="form.subtitle"
             :intro.sync="form.intro"
             :order.sync="form.order"
+            :enabled.sync="form.enabled"
             :sideboxes.sync="form.sideboxes"
             :category_taxonomies.sync="form.category_taxonomies"
             @update:image_file_id="form.image_file_id = $event"
@@ -58,6 +59,7 @@ export default {
         intro: "",
         subtitle: "",
         order: 1,
+        enabled: true,
         sideboxes: [],
         category_taxonomies: [],
         image_file_id: null

--- a/src/views/collections/personas/Edit.vue
+++ b/src/views/collections/personas/Edit.vue
@@ -32,6 +32,7 @@
               :subtitle.sync="form.subtitle"
               :intro.sync="form.intro"
               :order.sync="form.order"
+              :enabled.sync="form.enabled"
               :sideboxes.sync="form.sideboxes"
               :category_taxonomies.sync="form.category_taxonomies"
               @update:image_file_id="form.image_file_id = $event"
@@ -88,6 +89,7 @@ export default {
         subtitle: this.collection.subtitle,
         intro: this.collection.intro,
         order: this.collection.order,
+        enabled: this.collection.enabled,
         sideboxes: this.collection.sideboxes,
         category_taxonomies: this.collection.category_taxonomies.map(
           taxonomy => taxonomy.id

--- a/src/views/collections/personas/forms/CollectionForm.vue
+++ b/src/views/collections/personas/forms/CollectionForm.vue
@@ -47,6 +47,15 @@
       "
     />
 
+    <collection-enabled-input
+      :value="enabled"
+      @input="onInput('enabled', $event)"
+      id="status"
+      type="category"
+      label="Status of Category"
+      :error="errors.get('enabled')"
+    />
+
     <gov-heading size="m">Sideboxes</gov-heading>
 
     <gov-body>
@@ -77,10 +86,16 @@
 import CkImageInput from "@/components/Ck/CkImageInput";
 import CkTaxonomyInput from "@/components/Ck/CkTaxonomyInput";
 import CkSideboxesInput from "@/views/collections/inputs/SideboxesInput";
+import CollectionEnabledInput from "@/views/collections/inputs/CollectionEnabledInput";
 
 export default {
   name: "CollectionForm",
-  components: { CkImageInput, CkTaxonomyInput, CkSideboxesInput },
+  components: {
+    CollectionEnabledInput,
+    CkImageInput,
+    CkTaxonomyInput,
+    CkSideboxesInput
+  },
   props: {
     errors: {
       required: true,
@@ -96,6 +111,9 @@ export default {
       required: true
     },
     order: {
+      required: true
+    },
+    enabled: {
       required: true
     },
     sideboxes: {


### PR DESCRIPTION
### Summary
https://app.clubhouse.io/ayup-digital-ltd/story/510/manage-enabled-flag-on-collections

- Added '(disabled)' to collection name when collection is not enabled
- Added UI to allow enable and disable existing collections (category and persona)
- Added UI to allow creating new disabled collections (category and persona)

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
NA

### Notes
NA
