### PR TITLE
Feature/hounslow ch497 admin pages to update eligibility taxonomies

### DIFF
--- a/src/components/Ck/CkTaxonomyList.vue
+++ b/src/components/Ck/CkTaxonomyList.vue
@@ -1,11 +1,29 @@
 <template>
-  <gov-list>
+  <gov-list :bullet="bullet">
     <li
       v-for="taxonomy in taxonomies"
       v-if="showListItem(taxonomy)"
       :key="taxonomy.id"
     >
       {{ taxonomy.name }}
+      <span v-if="edit.length > 0 && auth.isGlobalAdmin">
+        <gov-link
+          :to="{
+            name: edit,
+            params: { taxonomy: taxonomy.id }
+          }"
+        >
+          Edit </gov-link
+        >&nbsp;
+        <gov-link @click="$emit('move-up', taxonomy)" v-if="taxonomy.order > 1"
+          >(Move up)</gov-link
+        >&nbsp;
+        <gov-link
+          @click="$emit('move-down', taxonomy)"
+          v-if="taxonomy.order < taxonomies.length"
+          >(Move down)</gov-link
+        >
+      </span>
       <gov-hint :for="taxonomy.id" v-if="taxonomyCollections[taxonomy.id]"
         >Found in {{ taxonomyCollections[taxonomy.id].join(", ") }}</gov-hint
       >
@@ -16,6 +34,8 @@
         :filteredTaxonomyIds="filteredTaxonomyIds"
         :taxonomyCollections="taxonomyCollections"
         :checkbox="false"
+        @moveUp="$emit('move-up', $event)"
+        @moveDown="$emit('move-down', $event)"
       />
     </li>
   </gov-list>
@@ -24,6 +44,7 @@
 <script>
 export default {
   name: "CkTaxonomyList",
+
   props: {
     taxonomies: {
       required: true,
@@ -40,6 +61,14 @@ export default {
       default() {
         return {};
       }
+    },
+    edit: {
+      type: String,
+      default: ""
+    },
+    bullet: {
+      type: Boolean,
+      default: false
     }
   },
 

--- a/src/router.js
+++ b/src/router.js
@@ -310,6 +310,12 @@ let router = new Router({
               name: "admin-index-taxonomies-organisations",
               component: () =>
                 import("@/views/admin/index/taxonomies/Organisations")
+            },
+            {
+              path: "service-eligibilities",
+              name: "admin-index-taxonomies-service-eligibilities",
+              component: () =>
+                import("@/views/admin/index/taxonomies/ServiceEligibilities")
             }
           ]
         },
@@ -452,6 +458,19 @@ let router = new Router({
       path: "/taxonomies/organisations/:taxonomy/edit",
       name: "taxonomies-organisations-edit",
       component: () => import("@/views/taxonomies/organisations/Edit"),
+      meta: { auth: true }
+    },
+    {
+      path: "/taxonomies/service-eligibilities/create",
+      name: "taxonomies-service-eligibilities-create",
+      component: () =>
+        import("@/views/taxonomies/service-eligibilities/Create"),
+      meta: { auth: true }
+    },
+    {
+      path: "/taxonomies/service-eligibilities/:taxonomy/edit",
+      name: "taxonomies-service-eligibilities-edit",
+      component: () => import("@/views/taxonomies/service-eligibilities/Edit"),
       meta: { auth: true }
     },
     {

--- a/src/views/admin/index/Taxonomies.vue
+++ b/src/views/admin/index/Taxonomies.vue
@@ -18,6 +18,10 @@ export default {
         {
           heading: "Organisations",
           to: { name: "admin-index-taxonomies-organisations" }
+        },
+        {
+          heading: "Service Eligibilities",
+          to: { name: "admin-index-taxonomies-service-eligibilities" }
         }
       ]
     };

--- a/src/views/admin/index/collections/Categories.vue
+++ b/src/views/admin/index/collections/Categories.vue
@@ -33,27 +33,15 @@
       <gov-grid-column width="two-thirds">
         <ck-loader v-if="loading" />
         <gov-list v-else bullet>
-          <li v-for="collection in collections" :key="collection.id">
-            {{ collection.name }}&nbsp;
-            <gov-link
-              v-if="auth.isGlobalAdmin"
-              :to="{
-                name: 'collections-categories-edit',
-                params: { collection: collection.id }
-              }"
-            >
-              Edit
-            </gov-link>
-            <br />
-            <gov-link @click="onMoveUp(collection)" v-if="collection.order > 1"
-              >(Move up)</gov-link
-            >
-            <gov-link
-              @click="onMoveDown(collection)"
-              v-if="collection.order < collections.length"
-              >(Move down)</gov-link
-            >
-          </li>
+          <collection-list-item
+            v-for="collection in collections"
+            :key="collection.id"
+            :collection="collection"
+            :collections="collections"
+            type="category"
+            @move-up="onMoveUp"
+            @move-down="onMoveDown"
+          />
         </gov-list>
       </gov-grid-column>
     </gov-grid-row>
@@ -62,9 +50,13 @@
 
 <script>
 import http from "@/http";
+import CollectionListItem from "./CollectionListItem";
 
 export default {
   name: "ListCollectionCategories",
+
+  components: { CollectionListItem },
+
   data() {
     return {
       loading: false,
@@ -103,6 +95,7 @@ export default {
         intro: collection.intro,
         icon: collection.icon,
         order: collection.order,
+        enabled: collection.enabled,
         sideboxes: collection.sideboxes,
         category_taxonomies: collection.category_taxonomies.map(
           taxonomy => taxonomy.id

--- a/src/views/admin/index/collections/CollectionListItem.vue
+++ b/src/views/admin/index/collections/CollectionListItem.vue
@@ -1,0 +1,58 @@
+<template>
+  <li>
+    {{ collection.name }}&nbsp;<span
+      v-if="auth.isSuperAdmin && !collection.enabled"
+      >(disabled)</span
+    >&nbsp;
+    <gov-link
+      v-if="auth.isGlobalAdmin"
+      :to="{
+        name: editCollectionRoute,
+        params: { collection: collection.id }
+      }"
+    >
+      Edit
+    </gov-link>
+    <br />
+    <gov-link @click="$emit('move-up', collection)" v-if="collection.order > 1"
+      >(Move up)</gov-link
+    >
+    <gov-link
+      @click="$emit('move-down', collection)"
+      v-if="collection.order < collections.length"
+      >(Move down)</gov-link
+    >
+  </li>
+</template>
+
+<script>
+export default {
+  props: {
+    collections: {
+      type: Array,
+      required: true
+    },
+    collection: {
+      type: Object,
+      required: true
+    },
+    type: {
+      type: String,
+      required: true,
+      validator: function(value) {
+        return ["category", "persona"].indexOf(value) !== -1;
+      }
+    }
+  },
+
+  computed: {
+    editCollectionRoute() {
+      return this.type === "category"
+        ? "collections-categories-edit"
+        : "collections-personas-edit";
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/views/admin/index/collections/Personas.vue
+++ b/src/views/admin/index/collections/Personas.vue
@@ -31,27 +31,15 @@
       <gov-grid-column width="two-thirds">
         <ck-loader v-if="loading" />
         <gov-list v-else bullet>
-          <li v-for="collection in collections" :key="collection.id">
-            {{ collection.name }}&nbsp;
-            <gov-link
-              v-if="auth.isGlobalAdmin"
-              :to="{
-                name: 'collections-personas-edit',
-                params: { collection: collection.id }
-              }"
-            >
-              Edit
-            </gov-link>
-            <br />
-            <gov-link @click="onMoveUp(collection)" v-if="collection.order > 1"
-              >(Move up)</gov-link
-            >
-            <gov-link
-              @click="onMoveDown(collection)"
-              v-if="collection.order < collections.length"
-              >(Move down)</gov-link
-            >
-          </li>
+          <collection-list-item
+            v-for="collection in collections"
+            :key="collection.id"
+            :collection="collection"
+            :collections="collections"
+            type="persona"
+            @move-up="onMoveUp"
+            @move-down="onMoveDown"
+          />
         </gov-list>
       </gov-grid-column>
     </gov-grid-row>
@@ -60,9 +48,13 @@
 
 <script>
 import http from "@/http";
+import CollectionListItem from "./CollectionListItem";
 
 export default {
   name: "ListCollectionPersonas",
+
+  components: { CollectionListItem },
+
   data() {
     return {
       loading: false,
@@ -101,6 +93,7 @@ export default {
         intro: collection.intro,
         subtitle: collection.subtitle,
         order: collection.order,
+        enabled: collection.enabled,
         sideboxes: collection.sideboxes,
         category_taxonomies: collection.category_taxonomies.map(
           taxonomy => taxonomy.id

--- a/src/views/admin/index/taxonomies/ServiceEligibilities.vue
+++ b/src/views/admin/index/taxonomies/ServiceEligibilities.vue
@@ -1,0 +1,101 @@
+<template>
+  <div>
+    <gov-grid-row>
+      <gov-grid-column width="two-thirds">
+        <gov-heading size="l">Taxonomy: Service Eligibilities</gov-heading>
+
+        <gov-body>
+          Taxonomies are the 'tags' that we assign to services, in order for
+          them to appear within search results and categories. They are pulled
+          from the
+          <gov-link href="https://about.auntbertha.com/openeligibility"
+            >Aunt Bertha Open Eligibility Standard</gov-link
+          >.
+        </gov-body>
+
+        <gov-body>
+          From this page, you can edit the taxonomies available to be applied to
+          a service, as well as add new ones.
+        </gov-body>
+      </gov-grid-column>
+
+      <gov-grid-column v-if="auth.isSuperAdmin" width="one-third">
+        <gov-button
+          :to="{ name: 'taxonomies-service-eligibilities-create' }"
+          success
+          expand
+          >Add a new service eligibility</gov-button
+        >
+      </gov-grid-column>
+    </gov-grid-row>
+
+    <gov-section-break size="l" />
+
+    <gov-grid-row
+      v-for="rootTaxonomy in serviceEligibilities"
+      :key="rootTaxonomy.id"
+    >
+      <gov-grid-column width="two-thirds">
+        <gov-heading size="m">{{ rootTaxonomy.name }}</gov-heading>
+        <ck-taxonomy-list
+          :taxonomies="rootTaxonomy.children"
+          :filteredTaxonomyIds="true"
+          edit="taxonomies-service-eligibilities-edit"
+          :bullet="true"
+          @move-up="onMoveUp"
+          @move-down="onMoveDown"
+        />
+      </gov-grid-column>
+    </gov-grid-row>
+  </div>
+</template>
+
+<script>
+import http from "@/http";
+import CkTaxonomyList from "@/components/Ck/CkTaxonomyList";
+
+export default {
+  name: "ListTaxonomyServiceEligibilitied",
+
+  components: {
+    CkTaxonomyList
+  },
+
+  data() {
+    return {
+      loading: false,
+      serviceEligibilities: []
+    };
+  },
+
+  methods: {
+    async fetchServiceEligibilities() {
+      this.loading = true;
+
+      const { data } = await http.get("/taxonomies/service-eligibilities");
+      this.serviceEligibilities = data.data;
+
+      this.loading = false;
+    },
+    async onMoveUp(taxonomy) {
+      taxonomy.order--;
+      await http.put(`/taxonomies/service-eligibilities/${taxonomy.id}`, {
+        ...taxonomy
+      });
+      this.fetchServiceEligibilities();
+    },
+    async onMoveDown(taxonomy) {
+      taxonomy.order++;
+      await http.put(`/taxonomies/service-eligibilities/${taxonomy.id}`, {
+        ...taxonomy
+      });
+      this.fetchServiceEligibilities();
+    }
+  },
+  created() {
+    this.fetchServiceEligibilities();
+  }
+};
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/views/collections/categories/Create.vue
+++ b/src/views/collections/categories/Create.vue
@@ -25,6 +25,7 @@
             :intro.sync="form.intro"
             :icon.sync="form.icon"
             :order.sync="form.order"
+            :enabled.sync="form.enabled"
             :sideboxes.sync="form.sideboxes"
             :category_taxonomies.sync="form.category_taxonomies"
             @clear="form.$errors.clear($event)"
@@ -55,6 +56,7 @@ export default {
         intro: "",
         icon: "",
         order: 1,
+        enabled: true,
         sideboxes: [],
         category_taxonomies: []
       })

--- a/src/views/collections/categories/Edit.vue
+++ b/src/views/collections/categories/Edit.vue
@@ -31,6 +31,7 @@
               :intro.sync="form.intro"
               :icon.sync="form.icon"
               :order.sync="form.order"
+              :enabled.sync="form.enabled"
               :sideboxes.sync="form.sideboxes"
               :category_taxonomies.sync="form.category_taxonomies"
               @clear="form.$errors.clear($event)"
@@ -86,6 +87,7 @@ export default {
         intro: this.collection.intro,
         icon: this.collection.icon,
         order: this.collection.order,
+        enabled: this.collection.enabled,
         sideboxes: this.collection.sideboxes,
         category_taxonomies: this.collection.category_taxonomies.map(
           taxonomy => taxonomy.id

--- a/src/views/collections/categories/forms/CollectionForm.vue
+++ b/src/views/collections/categories/forms/CollectionForm.vue
@@ -46,6 +46,15 @@
       />
     </ck-select-input>
 
+    <collection-enabled-input
+      :value="enabled"
+      @input="onInput('enabled', $event)"
+      id="status"
+      type="category"
+      label="Status of Category"
+      :error="errors.get('enabled')"
+    />
+
     <gov-heading size="m">Sideboxes</gov-heading>
 
     <gov-body>
@@ -76,10 +85,11 @@
 import icons from "@/storage/icons";
 import CkTaxonomyInput from "@/components/Ck/CkTaxonomyInput";
 import CkSideboxesInput from "@/views/collections/inputs/SideboxesInput";
+import CollectionEnabledInput from "@/views/collections/inputs/CollectionEnabledInput";
 
 export default {
   name: "CollectionForm",
-  components: { CkTaxonomyInput, CkSideboxesInput },
+  components: { CollectionEnabledInput, CkTaxonomyInput, CkSideboxesInput },
   props: {
     errors: {
       required: true,
@@ -95,6 +105,9 @@ export default {
       required: true
     },
     order: {
+      required: true
+    },
+    enabled: {
       required: true
     },
     sideboxes: {

--- a/src/views/collections/inputs/CollectionEnabledInput.vue
+++ b/src/views/collections/inputs/CollectionEnabledInput.vue
@@ -1,0 +1,62 @@
+<template>
+  <gov-form-group :invalid="error !== null">
+    <gov-label :for="id" class="govuk-!-font-weight-bold">
+      <slot name="label">{{ label }}</slot>
+    </gov-label>
+    <slot name="hint">
+      <gov-hint v-if="hint" :for="id" v-text="hint" />
+    </slot>
+    <gov-radios>
+      <gov-radio
+        :bind-to="value"
+        @input="$emit('input', $event)"
+        :id="`${id}_enabled`"
+        :name="id"
+        label="Enabled"
+        :value="true"
+      />
+      <gov-radio
+        :bind-to="value"
+        @input="$emit('input', $event)"
+        :id="`${id}_disabled`"
+        :name="id"
+        label="Disabled"
+        :value="false"
+      />
+    </gov-radios>
+  </gov-form-group>
+</template>
+
+<script>
+export default {
+  props: {
+    value: {
+      required: true
+    },
+    error: {
+      required: true
+    },
+    id: {
+      type: String,
+      required: true
+    },
+    type: {
+      type: String,
+      required: true,
+      validator: function(value) {
+        return ["category", "persona"].indexOf(value) !== -1;
+      }
+    },
+    label: {
+      required: true,
+      type: String
+    },
+    hint: {
+      required: false,
+      type: String
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/views/collections/personas/Create.vue
+++ b/src/views/collections/personas/Create.vue
@@ -25,6 +25,7 @@
             :subtitle.sync="form.subtitle"
             :intro.sync="form.intro"
             :order.sync="form.order"
+            :enabled.sync="form.enabled"
             :sideboxes.sync="form.sideboxes"
             :category_taxonomies.sync="form.category_taxonomies"
             @update:image_file_id="form.image_file_id = $event"
@@ -58,6 +59,7 @@ export default {
         intro: "",
         subtitle: "",
         order: 1,
+        enabled: true,
         sideboxes: [],
         category_taxonomies: [],
         image_file_id: null

--- a/src/views/collections/personas/Edit.vue
+++ b/src/views/collections/personas/Edit.vue
@@ -32,6 +32,7 @@
               :subtitle.sync="form.subtitle"
               :intro.sync="form.intro"
               :order.sync="form.order"
+              :enabled.sync="form.enabled"
               :sideboxes.sync="form.sideboxes"
               :category_taxonomies.sync="form.category_taxonomies"
               @update:image_file_id="form.image_file_id = $event"
@@ -88,6 +89,7 @@ export default {
         subtitle: this.collection.subtitle,
         intro: this.collection.intro,
         order: this.collection.order,
+        enabled: this.collection.enabled,
         sideboxes: this.collection.sideboxes,
         category_taxonomies: this.collection.category_taxonomies.map(
           taxonomy => taxonomy.id

--- a/src/views/collections/personas/forms/CollectionForm.vue
+++ b/src/views/collections/personas/forms/CollectionForm.vue
@@ -47,6 +47,15 @@
       "
     />
 
+    <collection-enabled-input
+      :value="enabled"
+      @input="onInput('enabled', $event)"
+      id="status"
+      type="category"
+      label="Status of Category"
+      :error="errors.get('enabled')"
+    />
+
     <gov-heading size="m">Sideboxes</gov-heading>
 
     <gov-body>
@@ -77,10 +86,16 @@
 import CkImageInput from "@/components/Ck/CkImageInput";
 import CkTaxonomyInput from "@/components/Ck/CkTaxonomyInput";
 import CkSideboxesInput from "@/views/collections/inputs/SideboxesInput";
+import CollectionEnabledInput from "@/views/collections/inputs/CollectionEnabledInput";
 
 export default {
   name: "CollectionForm",
-  components: { CkImageInput, CkTaxonomyInput, CkSideboxesInput },
+  components: {
+    CollectionEnabledInput,
+    CkImageInput,
+    CkTaxonomyInput,
+    CkSideboxesInput
+  },
   props: {
     errors: {
       required: true,
@@ -96,6 +111,9 @@ export default {
       required: true
     },
     order: {
+      required: true
+    },
+    enabled: {
       required: true
     },
     sideboxes: {

--- a/src/views/locations/forms/LocationForm.vue
+++ b/src/views/locations/forms/LocationForm.vue
@@ -63,6 +63,12 @@
       :error="errors.get('country')"
     />
 
+    <gov-error-message
+      v-if="errors.has('address_not_found')"
+      v-text="errors.get('address_not_found')"
+      for="postcode"
+    />
+
     <gov-section-break size="l" />
 
     <gov-form-group

--- a/src/views/services/Create.vue
+++ b/src/views/services/Create.vue
@@ -87,7 +87,6 @@
               :contact_name.sync="form.contact_name"
               :contact_phone.sync="form.contact_phone"
               :contact_email.sync="form.contact_email"
-              :social_medias.sync="form.social_medias"
             >
               <gov-button @click="onNext" start>Next</gov-button>
             </additional-info-tab>
@@ -243,7 +242,6 @@ export default {
           }
         ],
         offerings: [],
-        social_medias: [],
         gallery_items: [],
         category_taxonomies: [],
         eligibility_types: {

--- a/src/views/services/Edit.vue
+++ b/src/views/services/Edit.vue
@@ -75,7 +75,6 @@
                   :contact_name.sync="form.contact_name"
                   :contact_phone.sync="form.contact_phone"
                   :contact_email.sync="form.contact_email"
-                  :social_medias.sync="form.social_medias"
                 >
                   <gov-button @click="onNext" start>Next</gov-button>
                 </additional-info-tab>
@@ -309,7 +308,6 @@ export default {
         referral_url: this.service.referral_url || "",
         useful_infos: this.service.useful_infos,
         offerings: this.service.offerings,
-        social_medias: this.service.social_medias,
         gallery_items: this.service.gallery_items.map(galleryItem => ({
           file_id: galleryItem.file_id,
           image: null
@@ -417,12 +415,6 @@ export default {
             JSON.stringify(this.service.offerings)
           ) {
             delete data.offerings;
-          }
-          if (
-            JSON.stringify(data.social_medias) ===
-            JSON.stringify(this.service.social_medias)
-          ) {
-            delete data.social_medias;
           }
           if (
             JSON.stringify(data.category_taxonomies) ===

--- a/src/views/services/forms/AdditionalInfoTab.vue
+++ b/src/views/services/forms/AdditionalInfoTab.vue
@@ -205,26 +205,6 @@
           type="email"
           :error="errors.get('contact_email')"
         />
-
-        <gov-section-break size="l" />
-
-        <gov-heading size="m">Social media links</gov-heading>
-
-        <gov-body>
-          If you have any social media accounts for your {{ type }}, please
-          select the appropriate platform from the dropdown and add the relevant
-          URL.
-        </gov-body>
-        <gov-body>
-          If you don’t have accounts for the specific {{ type }}, please add the
-          accounts of the overall organisation.
-        </gov-body>
-
-        <ck-social-medias-input
-          :social-medias="social_medias"
-          @input="$emit('update:social_medias', $event)"
-          :errors="errors"
-        />
       </gov-grid-column>
     </gov-grid-row>
 
@@ -233,11 +213,8 @@
 </template>
 
 <script>
-import CkSocialMediasInput from "@/components/Ck/CkSocialMediasInput";
-
 export default {
   name: "AdditionalInfoTab",
-  components: { CkSocialMediasInput },
   props: {
     errors: {
       required: true
@@ -270,9 +247,6 @@ export default {
       required: true
     },
     contact_email: {
-      required: true
-    },
-    social_medias: {
       required: true
     }
   },

--- a/src/views/taxonomies/service-eligibilities/Create.vue
+++ b/src/views/taxonomies/service-eligibilities/Create.vue
@@ -1,0 +1,67 @@
+<template>
+  <gov-width-container>
+    <vue-headful title="One Hounslow Connect - Add Service Eligibility" />
+
+    <gov-back-link
+      :to="{ name: 'admin-index-taxonomies-service-eligibilities' }"
+      >Back to taxonomy service eligibilities</gov-back-link
+    >
+    <gov-main-wrapper>
+      <gov-grid-row>
+        <gov-grid-column width="one-half">
+          <gov-heading size="xl">
+            <gov-caption size="xl">Taxonomies</gov-caption>
+            Service Eligibilities
+          </gov-heading>
+          <gov-heading size="m">Add service eligibility</gov-heading>
+          <gov-body>
+            From this page you can add the name of the taxonomy 'tags' on the
+            site and how they relate to each other. These should not be added
+            without reviewing wider impact on the site
+          </gov-body>
+
+          <service-eligibility-form
+            :errors="form.$errors"
+            :parent_id.sync="form.parent_id"
+            :name.sync="form.name"
+            :order.sync="form.order"
+            @clear="form.$errors.clear($event)"
+          />
+
+          <gov-button v-if="form.$submitting" disabled type="submit"
+            >Creating...</gov-button
+          >
+          <gov-button v-else @click="onSubmit" type="submit">Create</gov-button>
+          <ck-submit-error v-if="form.$errors.any()" />
+        </gov-grid-column>
+      </gov-grid-row>
+    </gov-main-wrapper>
+  </gov-width-container>
+</template>
+
+<script>
+import ServiceEligibilityForm from "./forms/ServiceEligibilityForm";
+import Form from "@/classes/Form";
+
+export default {
+  name: "CreateTaxonomyServiceEligibility",
+  components: { ServiceEligibilityForm },
+  data() {
+    return {
+      form: new Form({
+        parent_id: null,
+        name: "",
+        order: 1
+      })
+    };
+  },
+  methods: {
+    async onSubmit() {
+      await this.form.post("/taxonomies/service-eligibilities");
+      this.$router.push({
+        name: "admin-index-taxonomies-service-eligibilities"
+      });
+    }
+  }
+};
+</script>

--- a/src/views/taxonomies/service-eligibilities/Edit.vue
+++ b/src/views/taxonomies/service-eligibilities/Edit.vue
@@ -1,0 +1,110 @@
+<template>
+  <gov-width-container>
+    <ck-loader v-if="loading" />
+    <template v-else>
+      <vue-headful
+        :title="
+          `One Hounslow Connect - Edit Service Eligibility: ${serviceEligibility.name}`
+        "
+      />
+
+      <gov-back-link
+        :to="{ name: 'admin-index-taxonomies-service-eligibilities' }"
+        >Back to taxonomy service eligibilities</gov-back-link
+      >
+      <gov-main-wrapper>
+        <gov-grid-row>
+          <gov-grid-column width="one-half">
+            <gov-heading size="xl">
+              <gov-caption size="xl">Taxonomies</gov-caption>
+              Service Eligibilities
+            </gov-heading>
+            <gov-heading size="m">Edit service eligibility</gov-heading>
+            <gov-body>
+              From this page you can change the name of the taxonomy 'tags' on
+              the site and how they relate to each other. These should not be
+              changed without reviewing wider impact on the site
+            </gov-body>
+
+            <service-eligibility-form
+              :errors="form.$errors"
+              :parent_id.sync="form.parent_id"
+              :name.sync="form.name"
+              :order.sync="form.order"
+              @clear="form.$errors.clear($event)"
+            />
+
+            <gov-button v-if="form.$submitting" disabled type="submit"
+              >Updating...</gov-button
+            >
+            <gov-button v-else @click="onSubmit" type="submit"
+              >Update</gov-button
+            >
+            <ck-submit-error v-if="form.$errors.any()" />
+
+            <gov-section-break size="l" />
+
+            <ck-delete-button
+              resource="category"
+              :endpoint="
+                `/taxonomies/service-eligibilities/${this.serviceEligibility.id}`
+              "
+              @deleted="onDelete"
+            />
+          </gov-grid-column>
+        </gov-grid-row>
+      </gov-main-wrapper>
+    </template>
+  </gov-width-container>
+</template>
+
+<script>
+import http from "@/http";
+import Form from "@/classes/Form";
+import ServiceEligibilityForm from "./forms/ServiceEligibilityForm";
+
+export default {
+  name: "EditTaxonomyServiceEligibility",
+  components: { ServiceEligibilityForm },
+  data() {
+    return {
+      loading: false,
+      serviceEligibility: null,
+      form: null
+    };
+  },
+  methods: {
+    async fetchServiceEligibility() {
+      this.loading = true;
+
+      const response = await http.get(
+        `/taxonomies/service-eligibilities/${this.$route.params.taxonomy}`
+      );
+      this.serviceEligibility = response.data.data;
+      this.form = new Form({
+        parent_id: this.serviceEligibility.parent_id,
+        name: this.serviceEligibility.name,
+        order: this.serviceEligibility.order
+      });
+
+      this.loading = false;
+    },
+    async onSubmit() {
+      await this.form.put(
+        `/taxonomies/service-eligibilities/${this.serviceEligibility.id}`
+      );
+      this.$router.push({
+        name: "admin-index-taxonomies-service-eligibilities"
+      });
+    },
+    onDelete() {
+      this.$router.push({
+        name: "admin-index-taxonomies-service-eligibilities"
+      });
+    }
+  },
+  created() {
+    this.fetchServiceEligibility();
+  }
+};
+</script>

--- a/src/views/taxonomies/service-eligibilities/forms/ServiceEligibilityForm.vue
+++ b/src/views/taxonomies/service-eligibilities/forms/ServiceEligibilityForm.vue
@@ -1,0 +1,81 @@
+<template>
+  <div>
+    <ck-text-input
+      :value="name"
+      @input="onInput('name', $event)"
+      id="name"
+      label="Name"
+      type="text"
+      :error="errors.get('name')"
+    />
+
+    <ck-loader v-if="loading" />
+    <ck-select-input
+      v-else
+      :value="parent_id"
+      @input="onInput('parent_id', $event)"
+      id="parent_id"
+      label="Parent"
+      :options="topLevelServiceEligibilities"
+      :error="errors.get('parent_id')"
+    />
+  </div>
+</template>
+
+<script>
+import http from "@/http";
+
+export default {
+  name: "ServiceEligibilityForm",
+  props: {
+    errors: {
+      required: true,
+      type: Object
+    },
+    parent_id: {
+      required: true
+    },
+    name: {
+      required: true
+    },
+    order: {
+      required: true
+    }
+  },
+  data() {
+    return {
+      loading: false,
+      serviceEligibilities: []
+    };
+  },
+
+  computed: {
+    topLevelServiceEligibilities() {
+      return [
+        { text: "Select an eligibility type", value: null },
+        ...this.serviceEligibilities.map(eligibility => {
+          return { text: eligibility.name, value: eligibility.id };
+        })
+      ];
+    }
+  },
+
+  methods: {
+    onInput(field, value) {
+      this.$emit(`update:${field}`, value);
+      this.$emit("clear", field);
+    },
+    async fetchServiceEligibilities() {
+      this.loading = true;
+
+      const { data } = await http.get("/taxonomies/service-eligibilities");
+      this.serviceEligibilities = data.data;
+
+      this.loading = false;
+    }
+  },
+  created() {
+    this.fetchServiceEligibilities();
+  }
+};
+</script>


### PR DESCRIPTION
### Summary
https://app.clubhouse.io/ayup-digital-ltd/story/497/admin-pages-to-update-eligibility-taxonomies

- Added Service Eligibilities tab to Admin Taxonomies
- Added Service Eligibilities list
- Added Edit button to list items
- Added Edit view for service eligibility
- Added Add new button for service eligibility
- Added Create view for service eligibility
- Added Move Up and Move Down functionality for service eligibility items

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
NA

### Notes
NA
