### PR TITLE
Service Eligibility admin UI

### DIFF
--- a/src/components/Ck/CkTaxonomyList.vue
+++ b/src/components/Ck/CkTaxonomyList.vue
@@ -1,11 +1,29 @@
 <template>
-  <gov-list>
+  <gov-list :bullet="bullet">
     <li
       v-for="taxonomy in taxonomies"
       v-if="showListItem(taxonomy)"
       :key="taxonomy.id"
     >
       {{ taxonomy.name }}
+      <span v-if="edit.length > 0 && auth.isGlobalAdmin">
+        <gov-link
+          :to="{
+            name: edit,
+            params: { taxonomy: taxonomy.id }
+          }"
+        >
+          Edit </gov-link
+        >&nbsp;
+        <gov-link @click="$emit('move-up', taxonomy)" v-if="taxonomy.order > 1"
+          >(Move up)</gov-link
+        >&nbsp;
+        <gov-link
+          @click="$emit('move-down', taxonomy)"
+          v-if="taxonomy.order < taxonomies.length"
+          >(Move down)</gov-link
+        >
+      </span>
       <gov-hint :for="taxonomy.id" v-if="taxonomyCollections[taxonomy.id]"
         >Found in {{ taxonomyCollections[taxonomy.id].join(", ") }}</gov-hint
       >
@@ -16,6 +34,8 @@
         :filteredTaxonomyIds="filteredTaxonomyIds"
         :taxonomyCollections="taxonomyCollections"
         :checkbox="false"
+        @moveUp="$emit('move-up', $event)"
+        @moveDown="$emit('move-down', $event)"
       />
     </li>
   </gov-list>
@@ -24,6 +44,7 @@
 <script>
 export default {
   name: "CkTaxonomyList",
+
   props: {
     taxonomies: {
       required: true,
@@ -40,6 +61,14 @@ export default {
       default() {
         return {};
       }
+    },
+    edit: {
+      type: String,
+      default: ""
+    },
+    bullet: {
+      type: Boolean,
+      default: false
     }
   },
 

--- a/src/router.js
+++ b/src/router.js
@@ -310,6 +310,12 @@ let router = new Router({
               name: "admin-index-taxonomies-organisations",
               component: () =>
                 import("@/views/admin/index/taxonomies/Organisations")
+            },
+            {
+              path: "service-eligibilities",
+              name: "admin-index-taxonomies-service-eligibilities",
+              component: () =>
+                import("@/views/admin/index/taxonomies/ServiceEligibilities")
             }
           ]
         },
@@ -452,6 +458,19 @@ let router = new Router({
       path: "/taxonomies/organisations/:taxonomy/edit",
       name: "taxonomies-organisations-edit",
       component: () => import("@/views/taxonomies/organisations/Edit"),
+      meta: { auth: true }
+    },
+    {
+      path: "/taxonomies/service-eligibilities/create",
+      name: "taxonomies-service-eligibilities-create",
+      component: () =>
+        import("@/views/taxonomies/service-eligibilities/Create"),
+      meta: { auth: true }
+    },
+    {
+      path: "/taxonomies/service-eligibilities/:taxonomy/edit",
+      name: "taxonomies-service-eligibilities-edit",
+      component: () => import("@/views/taxonomies/service-eligibilities/Edit"),
       meta: { auth: true }
     },
     {

--- a/src/views/admin/index/Taxonomies.vue
+++ b/src/views/admin/index/Taxonomies.vue
@@ -18,6 +18,10 @@ export default {
         {
           heading: "Organisations",
           to: { name: "admin-index-taxonomies-organisations" }
+        },
+        {
+          heading: "Service Eligibilities",
+          to: { name: "admin-index-taxonomies-service-eligibilities" }
         }
       ]
     };

--- a/src/views/admin/index/taxonomies/ServiceEligibilities.vue
+++ b/src/views/admin/index/taxonomies/ServiceEligibilities.vue
@@ -1,0 +1,101 @@
+<template>
+  <div>
+    <gov-grid-row>
+      <gov-grid-column width="two-thirds">
+        <gov-heading size="l">Taxonomy: Service Eligibilities</gov-heading>
+
+        <gov-body>
+          Taxonomies are the 'tags' that we assign to services, in order for
+          them to appear within search results and categories. They are pulled
+          from the
+          <gov-link href="https://about.auntbertha.com/openeligibility"
+            >Aunt Bertha Open Eligibility Standard</gov-link
+          >.
+        </gov-body>
+
+        <gov-body>
+          From this page, you can edit the taxonomies available to be applied to
+          a service, as well as add new ones.
+        </gov-body>
+      </gov-grid-column>
+
+      <gov-grid-column v-if="auth.isSuperAdmin" width="one-third">
+        <gov-button
+          :to="{ name: 'taxonomies-service-eligibilities-create' }"
+          success
+          expand
+          >Add a new service eligibility</gov-button
+        >
+      </gov-grid-column>
+    </gov-grid-row>
+
+    <gov-section-break size="l" />
+
+    <gov-grid-row
+      v-for="rootTaxonomy in serviceEligibilities"
+      :key="rootTaxonomy.id"
+    >
+      <gov-grid-column width="two-thirds">
+        <gov-heading size="m">{{ rootTaxonomy.name }}</gov-heading>
+        <ck-taxonomy-list
+          :taxonomies="rootTaxonomy.children"
+          :filteredTaxonomyIds="true"
+          edit="taxonomies-service-eligibilities-edit"
+          :bullet="true"
+          @move-up="onMoveUp"
+          @move-down="onMoveDown"
+        />
+      </gov-grid-column>
+    </gov-grid-row>
+  </div>
+</template>
+
+<script>
+import http from "@/http";
+import CkTaxonomyList from "@/components/Ck/CkTaxonomyList";
+
+export default {
+  name: "ListTaxonomyServiceEligibilitied",
+
+  components: {
+    CkTaxonomyList
+  },
+
+  data() {
+    return {
+      loading: false,
+      serviceEligibilities: []
+    };
+  },
+
+  methods: {
+    async fetchServiceEligibilities() {
+      this.loading = true;
+
+      const { data } = await http.get("/taxonomies/service-eligibilities");
+      this.serviceEligibilities = data.data;
+
+      this.loading = false;
+    },
+    async onMoveUp(taxonomy) {
+      taxonomy.order--;
+      await http.put(`/taxonomies/service-eligibilities/${taxonomy.id}`, {
+        ...taxonomy
+      });
+      this.fetchServiceEligibilities();
+    },
+    async onMoveDown(taxonomy) {
+      taxonomy.order++;
+      await http.put(`/taxonomies/service-eligibilities/${taxonomy.id}`, {
+        ...taxonomy
+      });
+      this.fetchServiceEligibilities();
+    }
+  },
+  created() {
+    this.fetchServiceEligibilities();
+  }
+};
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/views/taxonomies/service-eligibilities/Create.vue
+++ b/src/views/taxonomies/service-eligibilities/Create.vue
@@ -1,0 +1,67 @@
+<template>
+  <gov-width-container>
+    <vue-headful title="One Hounslow Connect - Add Service Eligibility" />
+
+    <gov-back-link
+      :to="{ name: 'admin-index-taxonomies-service-eligibilities' }"
+      >Back to taxonomy service eligibilities</gov-back-link
+    >
+    <gov-main-wrapper>
+      <gov-grid-row>
+        <gov-grid-column width="one-half">
+          <gov-heading size="xl">
+            <gov-caption size="xl">Taxonomies</gov-caption>
+            Service Eligibilities
+          </gov-heading>
+          <gov-heading size="m">Add service eligibility</gov-heading>
+          <gov-body>
+            From this page you can add the name of the taxonomy 'tags' on the
+            site and how they relate to each other. These should not be added
+            without reviewing wider impact on the site
+          </gov-body>
+
+          <service-eligibility-form
+            :errors="form.$errors"
+            :parent_id.sync="form.parent_id"
+            :name.sync="form.name"
+            :order.sync="form.order"
+            @clear="form.$errors.clear($event)"
+          />
+
+          <gov-button v-if="form.$submitting" disabled type="submit"
+            >Creating...</gov-button
+          >
+          <gov-button v-else @click="onSubmit" type="submit">Create</gov-button>
+          <ck-submit-error v-if="form.$errors.any()" />
+        </gov-grid-column>
+      </gov-grid-row>
+    </gov-main-wrapper>
+  </gov-width-container>
+</template>
+
+<script>
+import ServiceEligibilityForm from "./forms/ServiceEligibilityForm";
+import Form from "@/classes/Form";
+
+export default {
+  name: "CreateTaxonomyServiceEligibility",
+  components: { ServiceEligibilityForm },
+  data() {
+    return {
+      form: new Form({
+        parent_id: null,
+        name: "",
+        order: 1
+      })
+    };
+  },
+  methods: {
+    async onSubmit() {
+      await this.form.post("/taxonomies/service-eligibilities");
+      this.$router.push({
+        name: "admin-index-taxonomies-service-eligibilities"
+      });
+    }
+  }
+};
+</script>

--- a/src/views/taxonomies/service-eligibilities/Edit.vue
+++ b/src/views/taxonomies/service-eligibilities/Edit.vue
@@ -1,0 +1,110 @@
+<template>
+  <gov-width-container>
+    <ck-loader v-if="loading" />
+    <template v-else>
+      <vue-headful
+        :title="
+          `One Hounslow Connect - Edit Service Eligibility: ${serviceEligibility.name}`
+        "
+      />
+
+      <gov-back-link
+        :to="{ name: 'admin-index-taxonomies-service-eligibilities' }"
+        >Back to taxonomy service eligibilities</gov-back-link
+      >
+      <gov-main-wrapper>
+        <gov-grid-row>
+          <gov-grid-column width="one-half">
+            <gov-heading size="xl">
+              <gov-caption size="xl">Taxonomies</gov-caption>
+              Service Eligibilities
+            </gov-heading>
+            <gov-heading size="m">Edit service eligibility</gov-heading>
+            <gov-body>
+              From this page you can change the name of the taxonomy 'tags' on
+              the site and how they relate to each other. These should not be
+              changed without reviewing wider impact on the site
+            </gov-body>
+
+            <service-eligibility-form
+              :errors="form.$errors"
+              :parent_id.sync="form.parent_id"
+              :name.sync="form.name"
+              :order.sync="form.order"
+              @clear="form.$errors.clear($event)"
+            />
+
+            <gov-button v-if="form.$submitting" disabled type="submit"
+              >Updating...</gov-button
+            >
+            <gov-button v-else @click="onSubmit" type="submit"
+              >Update</gov-button
+            >
+            <ck-submit-error v-if="form.$errors.any()" />
+
+            <gov-section-break size="l" />
+
+            <ck-delete-button
+              resource="category"
+              :endpoint="
+                `/taxonomies/service-eligibilities/${this.serviceEligibility.id}`
+              "
+              @deleted="onDelete"
+            />
+          </gov-grid-column>
+        </gov-grid-row>
+      </gov-main-wrapper>
+    </template>
+  </gov-width-container>
+</template>
+
+<script>
+import http from "@/http";
+import Form from "@/classes/Form";
+import ServiceEligibilityForm from "./forms/ServiceEligibilityForm";
+
+export default {
+  name: "EditTaxonomyServiceEligibility",
+  components: { ServiceEligibilityForm },
+  data() {
+    return {
+      loading: false,
+      serviceEligibility: null,
+      form: null
+    };
+  },
+  methods: {
+    async fetchServiceEligibility() {
+      this.loading = true;
+
+      const response = await http.get(
+        `/taxonomies/service-eligibilities/${this.$route.params.taxonomy}`
+      );
+      this.serviceEligibility = response.data.data;
+      this.form = new Form({
+        parent_id: this.serviceEligibility.parent_id,
+        name: this.serviceEligibility.name,
+        order: this.serviceEligibility.order
+      });
+
+      this.loading = false;
+    },
+    async onSubmit() {
+      await this.form.put(
+        `/taxonomies/service-eligibilities/${this.serviceEligibility.id}`
+      );
+      this.$router.push({
+        name: "admin-index-taxonomies-service-eligibilities"
+      });
+    },
+    onDelete() {
+      this.$router.push({
+        name: "admin-index-taxonomies-service-eligibilities"
+      });
+    }
+  },
+  created() {
+    this.fetchServiceEligibility();
+  }
+};
+</script>

--- a/src/views/taxonomies/service-eligibilities/forms/ServiceEligibilityForm.vue
+++ b/src/views/taxonomies/service-eligibilities/forms/ServiceEligibilityForm.vue
@@ -1,0 +1,81 @@
+<template>
+  <div>
+    <ck-text-input
+      :value="name"
+      @input="onInput('name', $event)"
+      id="name"
+      label="Name"
+      type="text"
+      :error="errors.get('name')"
+    />
+
+    <ck-loader v-if="loading" />
+    <ck-select-input
+      v-else
+      :value="parent_id"
+      @input="onInput('parent_id', $event)"
+      id="parent_id"
+      label="Parent"
+      :options="topLevelServiceEligibilities"
+      :error="errors.get('parent_id')"
+    />
+  </div>
+</template>
+
+<script>
+import http from "@/http";
+
+export default {
+  name: "ServiceEligibilityForm",
+  props: {
+    errors: {
+      required: true,
+      type: Object
+    },
+    parent_id: {
+      required: true
+    },
+    name: {
+      required: true
+    },
+    order: {
+      required: true
+    }
+  },
+  data() {
+    return {
+      loading: false,
+      serviceEligibilities: []
+    };
+  },
+
+  computed: {
+    topLevelServiceEligibilities() {
+      return [
+        { text: "Select an eligibility type", value: null },
+        ...this.serviceEligibilities.map(eligibility => {
+          return { text: eligibility.name, value: eligibility.id };
+        })
+      ];
+    }
+  },
+
+  methods: {
+    onInput(field, value) {
+      this.$emit(`update:${field}`, value);
+      this.$emit("clear", field);
+    },
+    async fetchServiceEligibilities() {
+      this.loading = true;
+
+      const { data } = await http.get("/taxonomies/service-eligibilities");
+      this.serviceEligibilities = data.data;
+
+      this.loading = false;
+    }
+  },
+  created() {
+    this.fetchServiceEligibilities();
+  }
+};
+</script>


### PR DESCRIPTION
### Summary
https://app.clubhouse.io/ayup-digital-ltd/story/497/admin-pages-to-update-eligibility-taxonomies

- Added Service Eligibilities tab to Admin Taxonomies
- Added Service Eligibilities list
-  Added Edit button to list items
-  Added Edit view for service eligibility
-  Added Add new button for service eligibility
-  Added Create view for service eligibility
-  Added Move Up and Move Down functionality for service eligibility items


### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
NA

### Notes
NA
