### PR TITLE
Feature/hounslow ch527 ux improvements to service eligibility

### DIFF
--- a/src/components/Ck/CkTaxonomyList.vue
+++ b/src/components/Ck/CkTaxonomyList.vue
@@ -1,5 +1,5 @@
 <template>
-  <gov-list v-if="filteredTaxonomies.length" :bullet="bullet">
+  <gov-list :bullet="bullet">
     <li v-for="taxonomy in filteredTaxonomies" :key="taxonomy.id">
       {{ taxonomy.name }}
       <span v-if="edit.length > 0 && auth.isGlobalAdmin">
@@ -36,9 +36,6 @@
       </ck-taxonomy-list>
     </li>
   </gov-list>
-  <div v-else>
-    <slot name="empty"></slot>
-  </div>
 </template>
 
 <script>

--- a/src/components/Ck/CkTaxonomyList.vue
+++ b/src/components/Ck/CkTaxonomyList.vue
@@ -1,10 +1,6 @@
 <template>
-  <gov-list :bullet="bullet">
-    <li
-      v-for="taxonomy in taxonomies"
-      v-if="showListItem(taxonomy)"
-      :key="taxonomy.id"
-    >
+  <gov-list v-if="filteredTaxonomies.length" :bullet="bullet">
+    <li v-for="taxonomy in filteredTaxonomies" :key="taxonomy.id">
       {{ taxonomy.name }}
       <span v-if="edit.length > 0 && auth.isGlobalAdmin">
         <gov-link
@@ -36,9 +32,13 @@
         :checkbox="false"
         @moveUp="$emit('move-up', $event)"
         @moveDown="$emit('move-down', $event)"
-      />
+      >
+      </ck-taxonomy-list>
     </li>
   </gov-list>
+  <div v-else>
+    <slot name="empty"></slot>
+  </div>
 </template>
 
 <script>
@@ -72,11 +72,13 @@ export default {
     }
   },
 
-  methods: {
-    showListItem(taxonomy) {
+  computed: {
+    filteredTaxonomies() {
       return Array.isArray(this.filteredTaxonomyIds)
-        ? this.filteredTaxonomyIds.includes(taxonomy.id)
-        : this.filteredTaxonomyIds;
+        ? this.taxonomies.filter(taxonomy => {
+            return this.filteredTaxonomyIds.includes(taxonomy.id);
+          })
+        : [];
     }
   }
 };

--- a/src/views/services/inputs/ServiceEligibilityInput.vue
+++ b/src/views/services/inputs/ServiceEligibilityInput.vue
@@ -7,6 +7,11 @@
       @input="onUpdateAccess"
       :id="`${customEligibilitySlug}_access`"
       label="Access to the service"
+      :hint="
+        access == 'some'
+          ? 'Changing access to all will remove current selections and custom values'
+          : ''
+      "
       :options="accessOptions"
       :error="null"
     />
@@ -19,6 +24,9 @@
       :filteredTaxonomyIds="true"
       @update="onUpdateTaxonomies"
     />
+
+    <gov-section-break size="l" />
+
     <ck-text-input
       v-if="access === 'some'"
       :value="customEligibilityValue"

--- a/src/views/services/show/EligibilityTab.vue
+++ b/src/views/services/show/EligibilityTab.vue
@@ -7,26 +7,19 @@
     >
       <gov-grid-column width="two-thirds">
         <gov-heading size="m">{{ rootTaxonomy.name }}</gov-heading>
-        <ck-taxonomy-list
-          :taxonomies="rootTaxonomy.children"
-          :filteredTaxonomyIds="service.eligibility_types.taxonomies"
-        >
-          <template slot="empty">
-            <gov-body
-              >No specific {{ rootTaxonomy.name }} criteria specified</gov-body
-            >
-          </template>
-        </ck-taxonomy-list>
-        <gov-body
-          v-if="
-            service.eligibility_types.hasOwnProperty('custom') &&
-              null !==
-                service.eligibility_types.custom[slugify(rootTaxonomy.name)]
-          "
-          >Custom Value:
-          {{
-            service.eligibility_types.custom[slugify(rootTaxonomy.name)]
-          }}</gov-body
+        <div v-if="serviceHasEligibilityCriteria(rootTaxonomy)">
+          <ck-taxonomy-list
+            :taxonomies="rootTaxonomy.children"
+            :filteredTaxonomyIds="service.eligibility_types.taxonomies"
+          />
+
+          <gov-body v-if="serviceEligibilityCustomValue(rootTaxonomy.name)"
+            >Custom Value:
+            {{ serviceEligibilityCustomValue(rootTaxonomy.name) }}</gov-body
+          >
+        </div>
+        <gov-body v-else
+          >No specific {{ rootTaxonomy.name }} criteria specified</gov-body
         >
       </gov-grid-column>
     </gov-grid-row>
@@ -66,6 +59,22 @@ export default {
       );
       this.eligibilityTypes = eligibilityTypes.data;
       this.loading = false;
+    },
+    serviceEligibilityCustomValue(name) {
+      const nameSlug = this.slugify(name);
+      return this.service.eligibility_types.hasOwnProperty("custom") &&
+        null !== this.service.eligibility_types.custom[nameSlug]
+        ? this.service.eligibility_types.custom[nameSlug]
+        : "";
+    },
+    serviceHasEligibilityCriteria(taxonomy) {
+      return (
+        taxonomy.children.some(childTaxonomy => {
+          return this.service.eligibility_types.taxonomies.includes(
+            childTaxonomy.id
+          );
+        }) || this.serviceEligibilityCustomValue(taxonomy.name) !== ""
+      );
     },
     slugify(name) {
       return name.toLowerCase().replaceAll(" ", "_");

--- a/src/views/services/show/EligibilityTab.vue
+++ b/src/views/services/show/EligibilityTab.vue
@@ -10,7 +10,13 @@
         <ck-taxonomy-list
           :taxonomies="rootTaxonomy.children"
           :filteredTaxonomyIds="service.eligibility_types.taxonomies"
-        />
+        >
+          <template slot="empty">
+            <gov-body
+              >No specific {{ rootTaxonomy.name }} criteria specified</gov-body
+            >
+          </template>
+        </ck-taxonomy-list>
         <gov-body
           v-if="
             service.eligibility_types.hasOwnProperty('custom') &&


### PR DESCRIPTION
### Summary
https://app.clubhouse.io/ayup-digital-ltd/story/527/ux-improvements-to-service-eligibility

- Updated Service show view Eligibility tab to show no criteria message if no eligibility taxonomies or custom criteria set
- Updated Service edit view Eligibility tab to show radio buttons with state based on eligibility taxonomies or custom criteria set
- Changing state of radio button will show or hide checkboxes and custom field
- Changing state from 'some' to 'all' will remove currently set service eligibilities and custom value

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
NA

### Notes
NA
